### PR TITLE
Configure dev proxy to reach backend

### DIFF
--- a/figma/README.md
+++ b/figma/README.md
@@ -5,7 +5,11 @@
 
   ## Running the code
 
-  Run `npm i` to install the dependencies.
+  1. Install dependencies with `npm i`.
+  2. Start the Go backend from `../backend` (for example with `go run ./cmd/api`). It listens on port `8080` by default.
+  3. Start the frontend dev server with `npm run dev`.
 
-  Run `npm run dev` to start the development server.
+  The Vite dev server proxies any `/api/*` calls to `http://localhost:8080`, so the UI uses real backend data without extra configuration. You can point the proxy to another backend URL by exporting `VITE_DEV_API_PROXY` (or `API_PROXY_TARGET`) before starting `npm run dev`.
+
+  For production builds where the frontend is hosted separately from the backend, set `VITE_API_BASE_URL` to the backend origin before running `npm run build`.
   

--- a/figma/package-lock.json
+++ b/figma/package-lock.json
@@ -1,0 +1,3479 @@
+{
+      "name": "Repo2Prompt Web Application Design",
+      "version": "0.1.0",
+      "lockfileVersion": 3,
+      "requires": true,
+      "packages": {
+            "": {
+                  "name": "Repo2Prompt Web Application Design",
+                  "version": "0.1.0",
+                  "dependencies": {
+                        "@radix-ui/react-accordion": "^1.2.3",
+                        "@radix-ui/react-alert-dialog": "^1.1.6",
+                        "@radix-ui/react-aspect-ratio": "^1.1.2",
+                        "@radix-ui/react-avatar": "^1.1.3",
+                        "@radix-ui/react-checkbox": "^1.1.4",
+                        "@radix-ui/react-collapsible": "^1.1.3",
+                        "@radix-ui/react-context-menu": "^2.2.6",
+                        "@radix-ui/react-dialog": "^1.1.6",
+                        "@radix-ui/react-dropdown-menu": "^2.1.6",
+                        "@radix-ui/react-hover-card": "^1.1.6",
+                        "@radix-ui/react-label": "^2.1.2",
+                        "@radix-ui/react-menubar": "^1.1.6",
+                        "@radix-ui/react-navigation-menu": "^1.2.5",
+                        "@radix-ui/react-popover": "^1.1.6",
+                        "@radix-ui/react-progress": "^1.1.2",
+                        "@radix-ui/react-radio-group": "^1.2.3",
+                        "@radix-ui/react-scroll-area": "^1.2.3",
+                        "@radix-ui/react-select": "^2.1.6",
+                        "@radix-ui/react-separator": "^1.1.2",
+                        "@radix-ui/react-slider": "^1.2.3",
+                        "@radix-ui/react-slot": "^1.1.2",
+                        "@radix-ui/react-switch": "^1.1.3",
+                        "@radix-ui/react-tabs": "^1.1.3",
+                        "@radix-ui/react-toggle": "^1.1.2",
+                        "@radix-ui/react-toggle-group": "^1.1.2",
+                        "@radix-ui/react-tooltip": "^1.1.8",
+                        "class-variance-authority": "^0.7.1",
+                        "clsx": "*",
+                        "cmdk": "^1.1.1",
+                        "embla-carousel-react": "^8.6.0",
+                        "input-otp": "^1.4.2",
+                        "lucide-react": "^0.487.0",
+                        "next-themes": "^0.4.6",
+                        "react": "^18.3.1",
+                        "react-day-picker": "^8.10.1",
+                        "react-dom": "^18.3.1",
+                        "react-hook-form": "^7.55.0",
+                        "react-resizable-panels": "^2.1.7",
+                        "recharts": "^2.15.2",
+                        "sonner": "^2.0.3",
+                        "tailwind-merge": "*",
+                        "vaul": "^1.1.2"
+                  },
+                  "devDependencies": {
+                        "@types/node": "^20.10.0",
+                        "@vitejs/plugin-react-swc": "^3.10.2",
+                        "vite": "6.3.5"
+                  }
+            },
+            "node_modules/@babel/runtime": {
+                  "version": "7.28.4",
+                  "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+                  "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=6.9.0"
+                  }
+            },
+            "node_modules/@esbuild/aix-ppc64": {
+                  "version": "0.25.10",
+                  "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
+                  "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
+                  "cpu": [
+                        "ppc64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "aix"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/android-arm": {
+                  "version": "0.25.10",
+                  "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
+                  "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
+                  "cpu": [
+                        "arm"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "android"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/android-arm64": {
+                  "version": "0.25.10",
+                  "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
+                  "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
+                  "cpu": [
+                        "arm64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "android"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/android-x64": {
+                  "version": "0.25.10",
+                  "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
+                  "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
+                  "cpu": [
+                        "x64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "android"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/darwin-arm64": {
+                  "version": "0.25.10",
+                  "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz",
+                  "integrity": "sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==",
+                  "cpu": [
+                        "arm64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "darwin"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/darwin-x64": {
+                  "version": "0.25.10",
+                  "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
+                  "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
+                  "cpu": [
+                        "x64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "darwin"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/freebsd-arm64": {
+                  "version": "0.25.10",
+                  "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
+                  "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
+                  "cpu": [
+                        "arm64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "freebsd"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/freebsd-x64": {
+                  "version": "0.25.10",
+                  "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
+                  "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
+                  "cpu": [
+                        "x64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "freebsd"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/linux-arm": {
+                  "version": "0.25.10",
+                  "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
+                  "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
+                  "cpu": [
+                        "arm"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/linux-arm64": {
+                  "version": "0.25.10",
+                  "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
+                  "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
+                  "cpu": [
+                        "arm64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/linux-ia32": {
+                  "version": "0.25.10",
+                  "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
+                  "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
+                  "cpu": [
+                        "ia32"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/linux-loong64": {
+                  "version": "0.25.10",
+                  "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
+                  "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
+                  "cpu": [
+                        "loong64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/linux-mips64el": {
+                  "version": "0.25.10",
+                  "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
+                  "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
+                  "cpu": [
+                        "mips64el"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/linux-ppc64": {
+                  "version": "0.25.10",
+                  "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
+                  "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
+                  "cpu": [
+                        "ppc64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/linux-riscv64": {
+                  "version": "0.25.10",
+                  "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
+                  "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
+                  "cpu": [
+                        "riscv64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/linux-s390x": {
+                  "version": "0.25.10",
+                  "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
+                  "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
+                  "cpu": [
+                        "s390x"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/linux-x64": {
+                  "version": "0.25.10",
+                  "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
+                  "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
+                  "cpu": [
+                        "x64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/netbsd-arm64": {
+                  "version": "0.25.10",
+                  "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz",
+                  "integrity": "sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==",
+                  "cpu": [
+                        "arm64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "netbsd"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/netbsd-x64": {
+                  "version": "0.25.10",
+                  "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
+                  "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
+                  "cpu": [
+                        "x64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "netbsd"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/openbsd-arm64": {
+                  "version": "0.25.10",
+                  "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
+                  "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
+                  "cpu": [
+                        "arm64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "openbsd"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/openbsd-x64": {
+                  "version": "0.25.10",
+                  "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
+                  "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
+                  "cpu": [
+                        "x64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "openbsd"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/openharmony-arm64": {
+                  "version": "0.25.10",
+                  "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz",
+                  "integrity": "sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==",
+                  "cpu": [
+                        "arm64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "openharmony"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/sunos-x64": {
+                  "version": "0.25.10",
+                  "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
+                  "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
+                  "cpu": [
+                        "x64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "sunos"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/win32-arm64": {
+                  "version": "0.25.10",
+                  "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
+                  "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
+                  "cpu": [
+                        "arm64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "win32"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/win32-ia32": {
+                  "version": "0.25.10",
+                  "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
+                  "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
+                  "cpu": [
+                        "ia32"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "win32"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/win32-x64": {
+                  "version": "0.25.10",
+                  "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
+                  "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
+                  "cpu": [
+                        "x64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "win32"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@floating-ui/core": {
+                  "version": "1.7.3",
+                  "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
+                  "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@floating-ui/utils": "^0.2.10"
+                  }
+            },
+            "node_modules/@floating-ui/dom": {
+                  "version": "1.7.4",
+                  "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
+                  "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@floating-ui/core": "^1.7.3",
+                        "@floating-ui/utils": "^0.2.10"
+                  }
+            },
+            "node_modules/@floating-ui/react-dom": {
+                  "version": "2.1.6",
+                  "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.6.tgz",
+                  "integrity": "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@floating-ui/dom": "^1.7.4"
+                  },
+                  "peerDependencies": {
+                        "react": ">=16.8.0",
+                        "react-dom": ">=16.8.0"
+                  }
+            },
+            "node_modules/@floating-ui/utils": {
+                  "version": "0.2.10",
+                  "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+                  "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+                  "license": "MIT"
+            },
+            "node_modules/@radix-ui/number": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+                  "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+                  "license": "MIT"
+            },
+            "node_modules/@radix-ui/primitive": {
+                  "version": "1.1.3",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+                  "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+                  "license": "MIT"
+            },
+            "node_modules/@radix-ui/react-accordion": {
+                  "version": "1.2.12",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.12.tgz",
+                  "integrity": "sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-collapsible": "1.1.12",
+                        "@radix-ui/react-collection": "1.1.7",
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-direction": "1.1.1",
+                        "@radix-ui/react-id": "1.1.1",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-use-controllable-state": "1.2.2"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-alert-dialog": {
+                  "version": "1.1.15",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz",
+                  "integrity": "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-dialog": "1.1.15",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-slot": "1.2.3"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-arrow": {
+                  "version": "1.1.7",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
+                  "integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/react-primitive": "2.1.3"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-aspect-ratio": {
+                  "version": "1.1.7",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.1.7.tgz",
+                  "integrity": "sha512-Yq6lvO9HQyPwev1onK1daHCHqXVLzPhSVjmsNjCa2Zcxy2f7uJD2itDtxknv6FzAKCwD1qQkeVDmX/cev13n/g==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/react-primitive": "2.1.3"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-avatar": {
+                  "version": "1.1.10",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.10.tgz",
+                  "integrity": "sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-use-callback-ref": "1.1.1",
+                        "@radix-ui/react-use-is-hydrated": "0.1.0",
+                        "@radix-ui/react-use-layout-effect": "1.1.1"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-checkbox": {
+                  "version": "1.3.3",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz",
+                  "integrity": "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-presence": "1.1.5",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-use-controllable-state": "1.2.2",
+                        "@radix-ui/react-use-previous": "1.1.1",
+                        "@radix-ui/react-use-size": "1.1.1"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-collapsible": {
+                  "version": "1.1.12",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.12.tgz",
+                  "integrity": "sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-id": "1.1.1",
+                        "@radix-ui/react-presence": "1.1.5",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-use-controllable-state": "1.2.2",
+                        "@radix-ui/react-use-layout-effect": "1.1.1"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-collection": {
+                  "version": "1.1.7",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+                  "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-slot": "1.2.3"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-compose-refs": {
+                  "version": "1.1.2",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+                  "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+                  "license": "MIT",
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-context": {
+                  "version": "1.1.2",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+                  "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+                  "license": "MIT",
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-context-menu": {
+                  "version": "2.2.16",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.2.16.tgz",
+                  "integrity": "sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-menu": "2.1.16",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-use-callback-ref": "1.1.1",
+                        "@radix-ui/react-use-controllable-state": "1.2.2"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-dialog": {
+                  "version": "1.1.15",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+                  "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-dismissable-layer": "1.1.11",
+                        "@radix-ui/react-focus-guards": "1.1.3",
+                        "@radix-ui/react-focus-scope": "1.1.7",
+                        "@radix-ui/react-id": "1.1.1",
+                        "@radix-ui/react-portal": "1.1.9",
+                        "@radix-ui/react-presence": "1.1.5",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-slot": "1.2.3",
+                        "@radix-ui/react-use-controllable-state": "1.2.2",
+                        "aria-hidden": "^1.2.4",
+                        "react-remove-scroll": "^2.6.3"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-direction": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+                  "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+                  "license": "MIT",
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-dismissable-layer": {
+                  "version": "1.1.11",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+                  "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-use-callback-ref": "1.1.1",
+                        "@radix-ui/react-use-escape-keydown": "1.1.1"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-dropdown-menu": {
+                  "version": "2.1.16",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz",
+                  "integrity": "sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-id": "1.1.1",
+                        "@radix-ui/react-menu": "2.1.16",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-use-controllable-state": "1.2.2"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-focus-guards": {
+                  "version": "1.1.3",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+                  "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+                  "license": "MIT",
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-focus-scope": {
+                  "version": "1.1.7",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+                  "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-use-callback-ref": "1.1.1"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-hover-card": {
+                  "version": "1.1.15",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.15.tgz",
+                  "integrity": "sha512-qgTkjNT1CfKMoP0rcasmlH2r1DAiYicWsDsufxl940sT2wHNEWWv6FMWIQXWhVdmC1d/HYfbhQx60KYyAtKxjg==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-dismissable-layer": "1.1.11",
+                        "@radix-ui/react-popper": "1.2.8",
+                        "@radix-ui/react-portal": "1.1.9",
+                        "@radix-ui/react-presence": "1.1.5",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-use-controllable-state": "1.2.2"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-id": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+                  "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/react-use-layout-effect": "1.1.1"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-label": {
+                  "version": "2.1.7",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.7.tgz",
+                  "integrity": "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/react-primitive": "2.1.3"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-menu": {
+                  "version": "2.1.16",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
+                  "integrity": "sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-collection": "1.1.7",
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-direction": "1.1.1",
+                        "@radix-ui/react-dismissable-layer": "1.1.11",
+                        "@radix-ui/react-focus-guards": "1.1.3",
+                        "@radix-ui/react-focus-scope": "1.1.7",
+                        "@radix-ui/react-id": "1.1.1",
+                        "@radix-ui/react-popper": "1.2.8",
+                        "@radix-ui/react-portal": "1.1.9",
+                        "@radix-ui/react-presence": "1.1.5",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-roving-focus": "1.1.11",
+                        "@radix-ui/react-slot": "1.2.3",
+                        "@radix-ui/react-use-callback-ref": "1.1.1",
+                        "aria-hidden": "^1.2.4",
+                        "react-remove-scroll": "^2.6.3"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-menubar": {
+                  "version": "1.1.16",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-menubar/-/react-menubar-1.1.16.tgz",
+                  "integrity": "sha512-EB1FktTz5xRRi2Er974AUQZWg2yVBb1yjip38/lgwtCVRd3a+maUoGHN/xs9Yv8SY8QwbSEb+YrxGadVWbEutA==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-collection": "1.1.7",
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-direction": "1.1.1",
+                        "@radix-ui/react-id": "1.1.1",
+                        "@radix-ui/react-menu": "2.1.16",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-roving-focus": "1.1.11",
+                        "@radix-ui/react-use-controllable-state": "1.2.2"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-navigation-menu": {
+                  "version": "1.2.14",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.14.tgz",
+                  "integrity": "sha512-YB9mTFQvCOAQMHU+C/jVl96WmuWeltyUEpRJJky51huhds5W2FQr1J8D/16sQlf0ozxkPK8uF3niQMdUwZPv5w==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-collection": "1.1.7",
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-direction": "1.1.1",
+                        "@radix-ui/react-dismissable-layer": "1.1.11",
+                        "@radix-ui/react-id": "1.1.1",
+                        "@radix-ui/react-presence": "1.1.5",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-use-callback-ref": "1.1.1",
+                        "@radix-ui/react-use-controllable-state": "1.2.2",
+                        "@radix-ui/react-use-layout-effect": "1.1.1",
+                        "@radix-ui/react-use-previous": "1.1.1",
+                        "@radix-ui/react-visually-hidden": "1.2.3"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-popover": {
+                  "version": "1.1.15",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
+                  "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-dismissable-layer": "1.1.11",
+                        "@radix-ui/react-focus-guards": "1.1.3",
+                        "@radix-ui/react-focus-scope": "1.1.7",
+                        "@radix-ui/react-id": "1.1.1",
+                        "@radix-ui/react-popper": "1.2.8",
+                        "@radix-ui/react-portal": "1.1.9",
+                        "@radix-ui/react-presence": "1.1.5",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-slot": "1.2.3",
+                        "@radix-ui/react-use-controllable-state": "1.2.2",
+                        "aria-hidden": "^1.2.4",
+                        "react-remove-scroll": "^2.6.3"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-popper": {
+                  "version": "1.2.8",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
+                  "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@floating-ui/react-dom": "^2.0.0",
+                        "@radix-ui/react-arrow": "1.1.7",
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-use-callback-ref": "1.1.1",
+                        "@radix-ui/react-use-layout-effect": "1.1.1",
+                        "@radix-ui/react-use-rect": "1.1.1",
+                        "@radix-ui/react-use-size": "1.1.1",
+                        "@radix-ui/rect": "1.1.1"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-portal": {
+                  "version": "1.1.9",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+                  "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-use-layout-effect": "1.1.1"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-presence": {
+                  "version": "1.1.5",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+                  "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-use-layout-effect": "1.1.1"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-primitive": {
+                  "version": "2.1.3",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+                  "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/react-slot": "1.2.3"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-progress": {
+                  "version": "1.1.7",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.7.tgz",
+                  "integrity": "sha512-vPdg/tF6YC/ynuBIJlk1mm7Le0VgW6ub6J2UWnTQ7/D23KXcPI1qy+0vBkgKgd38RCMJavBXpB83HPNFMTb0Fg==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-primitive": "2.1.3"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-radio-group": {
+                  "version": "1.3.8",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.3.8.tgz",
+                  "integrity": "sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-direction": "1.1.1",
+                        "@radix-ui/react-presence": "1.1.5",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-roving-focus": "1.1.11",
+                        "@radix-ui/react-use-controllable-state": "1.2.2",
+                        "@radix-ui/react-use-previous": "1.1.1",
+                        "@radix-ui/react-use-size": "1.1.1"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-roving-focus": {
+                  "version": "1.1.11",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+                  "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-collection": "1.1.7",
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-direction": "1.1.1",
+                        "@radix-ui/react-id": "1.1.1",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-use-callback-ref": "1.1.1",
+                        "@radix-ui/react-use-controllable-state": "1.2.2"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-scroll-area": {
+                  "version": "1.2.10",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.10.tgz",
+                  "integrity": "sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/number": "1.1.1",
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-direction": "1.1.1",
+                        "@radix-ui/react-presence": "1.1.5",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-use-callback-ref": "1.1.1",
+                        "@radix-ui/react-use-layout-effect": "1.1.1"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-select": {
+                  "version": "2.2.6",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.6.tgz",
+                  "integrity": "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/number": "1.1.1",
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-collection": "1.1.7",
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-direction": "1.1.1",
+                        "@radix-ui/react-dismissable-layer": "1.1.11",
+                        "@radix-ui/react-focus-guards": "1.1.3",
+                        "@radix-ui/react-focus-scope": "1.1.7",
+                        "@radix-ui/react-id": "1.1.1",
+                        "@radix-ui/react-popper": "1.2.8",
+                        "@radix-ui/react-portal": "1.1.9",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-slot": "1.2.3",
+                        "@radix-ui/react-use-callback-ref": "1.1.1",
+                        "@radix-ui/react-use-controllable-state": "1.2.2",
+                        "@radix-ui/react-use-layout-effect": "1.1.1",
+                        "@radix-ui/react-use-previous": "1.1.1",
+                        "@radix-ui/react-visually-hidden": "1.2.3",
+                        "aria-hidden": "^1.2.4",
+                        "react-remove-scroll": "^2.6.3"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-separator": {
+                  "version": "1.1.7",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.7.tgz",
+                  "integrity": "sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/react-primitive": "2.1.3"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-slider": {
+                  "version": "1.3.6",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.3.6.tgz",
+                  "integrity": "sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/number": "1.1.1",
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-collection": "1.1.7",
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-direction": "1.1.1",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-use-controllable-state": "1.2.2",
+                        "@radix-ui/react-use-layout-effect": "1.1.1",
+                        "@radix-ui/react-use-previous": "1.1.1",
+                        "@radix-ui/react-use-size": "1.1.1"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-slot": {
+                  "version": "1.2.3",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+                  "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/react-compose-refs": "1.1.2"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-switch": {
+                  "version": "1.2.6",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.6.tgz",
+                  "integrity": "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-use-controllable-state": "1.2.2",
+                        "@radix-ui/react-use-previous": "1.1.1",
+                        "@radix-ui/react-use-size": "1.1.1"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-tabs": {
+                  "version": "1.1.13",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+                  "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-direction": "1.1.1",
+                        "@radix-ui/react-id": "1.1.1",
+                        "@radix-ui/react-presence": "1.1.5",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-roving-focus": "1.1.11",
+                        "@radix-ui/react-use-controllable-state": "1.2.2"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-toggle": {
+                  "version": "1.1.10",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz",
+                  "integrity": "sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-use-controllable-state": "1.2.2"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-toggle-group": {
+                  "version": "1.1.11",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.11.tgz",
+                  "integrity": "sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-direction": "1.1.1",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-roving-focus": "1.1.11",
+                        "@radix-ui/react-toggle": "1.1.10",
+                        "@radix-ui/react-use-controllable-state": "1.2.2"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-tooltip": {
+                  "version": "1.2.8",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
+                  "integrity": "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-dismissable-layer": "1.1.11",
+                        "@radix-ui/react-id": "1.1.1",
+                        "@radix-ui/react-popper": "1.2.8",
+                        "@radix-ui/react-portal": "1.1.9",
+                        "@radix-ui/react-presence": "1.1.5",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-slot": "1.2.3",
+                        "@radix-ui/react-use-controllable-state": "1.2.2",
+                        "@radix-ui/react-visually-hidden": "1.2.3"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-use-callback-ref": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+                  "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+                  "license": "MIT",
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-use-controllable-state": {
+                  "version": "1.2.2",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+                  "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/react-use-effect-event": "0.0.2",
+                        "@radix-ui/react-use-layout-effect": "1.1.1"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-use-effect-event": {
+                  "version": "0.0.2",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+                  "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/react-use-layout-effect": "1.1.1"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-use-escape-keydown": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+                  "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/react-use-callback-ref": "1.1.1"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-use-is-hydrated": {
+                  "version": "0.1.0",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.0.tgz",
+                  "integrity": "sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "use-sync-external-store": "^1.5.0"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-use-layout-effect": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+                  "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+                  "license": "MIT",
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-use-previous": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+                  "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
+                  "license": "MIT",
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-use-rect": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
+                  "integrity": "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/rect": "1.1.1"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-use-size": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+                  "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/react-use-layout-effect": "1.1.1"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-visually-hidden": {
+                  "version": "1.2.3",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+                  "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/react-primitive": "2.1.3"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/rect": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
+                  "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
+                  "license": "MIT"
+            },
+            "node_modules/@rolldown/pluginutils": {
+                  "version": "1.0.0-beta.27",
+                  "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+                  "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+                  "dev": true,
+                  "license": "MIT"
+            },
+            "node_modules/@rollup/rollup-android-arm-eabi": {
+                  "version": "4.52.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.0.tgz",
+                  "integrity": "sha512-VxDYCDqOaR7NXzAtvRx7G1u54d2kEHopb28YH/pKzY6y0qmogP3gG7CSiWsq9WvDFxOQMpNEyjVAHZFXfH3o/A==",
+                  "cpu": [
+                        "arm"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "android"
+                  ]
+            },
+            "node_modules/@rollup/rollup-android-arm64": {
+                  "version": "4.52.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.0.tgz",
+                  "integrity": "sha512-pqDirm8koABIKvzL59YI9W9DWbRlTX7RWhN+auR8HXJxo89m4mjqbah7nJZjeKNTNYopqL+yGg+0mhCpf3xZtQ==",
+                  "cpu": [
+                        "arm64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "android"
+                  ]
+            },
+            "node_modules/@rollup/rollup-darwin-arm64": {
+                  "version": "4.52.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.0.tgz",
+                  "integrity": "sha512-YCdWlY/8ltN6H78HnMsRHYlPiKvqKagBP1r+D7SSylxX+HnsgXGCmLiV3Y4nSyY9hW8qr8U9LDUx/Lo7M6MfmQ==",
+                  "cpu": [
+                        "arm64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "darwin"
+                  ]
+            },
+            "node_modules/@rollup/rollup-darwin-x64": {
+                  "version": "4.52.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.0.tgz",
+                  "integrity": "sha512-z4nw6y1j+OOSGzuVbSWdIp1IUks9qNw4dc7z7lWuWDKojY38VMWBlEN7F9jk5UXOkUcp97vA1N213DF+Lz8BRg==",
+                  "cpu": [
+                        "x64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "darwin"
+                  ]
+            },
+            "node_modules/@rollup/rollup-freebsd-arm64": {
+                  "version": "4.52.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.0.tgz",
+                  "integrity": "sha512-Q/dv9Yvyr5rKlK8WQJZVrp5g2SOYeZUs9u/t2f9cQ2E0gJjYB/BWoedXfUT0EcDJefi2zzVfhcOj8drWCzTviw==",
+                  "cpu": [
+                        "arm64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "freebsd"
+                  ]
+            },
+            "node_modules/@rollup/rollup-freebsd-x64": {
+                  "version": "4.52.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.0.tgz",
+                  "integrity": "sha512-kdBsLs4Uile/fbjZVvCRcKB4q64R+1mUq0Yd7oU1CMm1Av336ajIFqNFovByipciuUQjBCPMxwJhCgfG2re3rg==",
+                  "cpu": [
+                        "x64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "freebsd"
+                  ]
+            },
+            "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+                  "version": "4.52.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.0.tgz",
+                  "integrity": "sha512-aL6hRwu0k7MTUESgkg7QHY6CoqPgr6gdQXRJI1/VbFlUMwsSzPGSR7sG5d+MCbYnJmJwThc2ol3nixj1fvI/zQ==",
+                  "cpu": [
+                        "arm"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ]
+            },
+            "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+                  "version": "4.52.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.0.tgz",
+                  "integrity": "sha512-BTs0M5s1EJejgIBJhCeiFo7GZZ2IXWkFGcyZhxX4+8usnIo5Mti57108vjXFIQmmJaRyDwmV59Tw64Ap1dkwMw==",
+                  "cpu": [
+                        "arm"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ]
+            },
+            "node_modules/@rollup/rollup-linux-arm64-gnu": {
+                  "version": "4.52.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.0.tgz",
+                  "integrity": "sha512-uj672IVOU9m08DBGvoPKPi/J8jlVgjh12C9GmjjBxCTQc3XtVmRkRKyeHSmIKQpvJ7fIm1EJieBUcnGSzDVFyw==",
+                  "cpu": [
+                        "arm64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ]
+            },
+            "node_modules/@rollup/rollup-linux-arm64-musl": {
+                  "version": "4.52.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.0.tgz",
+                  "integrity": "sha512-/+IVbeDMDCtB/HP/wiWsSzduD10SEGzIZX2945KSgZRNi4TSkjHqRJtNTVtVb8IRwhJ65ssI56krlLik+zFWkw==",
+                  "cpu": [
+                        "arm64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ]
+            },
+            "node_modules/@rollup/rollup-linux-loong64-gnu": {
+                  "version": "4.52.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.0.tgz",
+                  "integrity": "sha512-U1vVzvSWtSMWKKrGoROPBXMh3Vwn93TA9V35PldokHGqiUbF6erSzox/5qrSMKp6SzakvyjcPiVF8yB1xKr9Pg==",
+                  "cpu": [
+                        "loong64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ]
+            },
+            "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+                  "version": "4.52.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.0.tgz",
+                  "integrity": "sha512-X/4WfuBAdQRH8cK3DYl8zC00XEE6aM472W+QCycpQJeLWVnHfkv7RyBFVaTqNUMsTgIX8ihMjCvFF9OUgeABzw==",
+                  "cpu": [
+                        "ppc64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ]
+            },
+            "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+                  "version": "4.52.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.0.tgz",
+                  "integrity": "sha512-xIRYc58HfWDBZoLmWfWXg2Sq8VCa2iJ32B7mqfWnkx5mekekl0tMe7FHpY8I72RXEcUkaWawRvl3qA55og+cwQ==",
+                  "cpu": [
+                        "riscv64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ]
+            },
+            "node_modules/@rollup/rollup-linux-riscv64-musl": {
+                  "version": "4.52.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.0.tgz",
+                  "integrity": "sha512-mbsoUey05WJIOz8U1WzNdf+6UMYGwE3fZZnQqsM22FZ3wh1N887HT6jAOjXs6CNEK3Ntu2OBsyQDXfIjouI4dw==",
+                  "cpu": [
+                        "riscv64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ]
+            },
+            "node_modules/@rollup/rollup-linux-s390x-gnu": {
+                  "version": "4.52.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.0.tgz",
+                  "integrity": "sha512-qP6aP970bucEi5KKKR4AuPFd8aTx9EF6BvutvYxmZuWLJHmnq4LvBfp0U+yFDMGwJ+AIJEH5sIP+SNypauMWzg==",
+                  "cpu": [
+                        "s390x"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ]
+            },
+            "node_modules/@rollup/rollup-linux-x64-gnu": {
+                  "version": "4.52.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.0.tgz",
+                  "integrity": "sha512-nmSVN+F2i1yKZ7rJNKO3G7ZzmxJgoQBQZ/6c4MuS553Grmr7WqR7LLDcYG53Z2m9409z3JLt4sCOhLdbKQ3HmA==",
+                  "cpu": [
+                        "x64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ]
+            },
+            "node_modules/@rollup/rollup-linux-x64-musl": {
+                  "version": "4.52.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.0.tgz",
+                  "integrity": "sha512-2d0qRo33G6TfQVjaMR71P+yJVGODrt5V6+T0BDYH4EMfGgdC/2HWDVjSSFw888GSzAZUwuska3+zxNUCDco6rQ==",
+                  "cpu": [
+                        "x64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ]
+            },
+            "node_modules/@rollup/rollup-openharmony-arm64": {
+                  "version": "4.52.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.0.tgz",
+                  "integrity": "sha512-A1JalX4MOaFAAyGgpO7XP5khquv/7xKzLIyLmhNrbiCxWpMlnsTYr8dnsWM7sEeotNmxvSOEL7F65j0HXFcFsw==",
+                  "cpu": [
+                        "arm64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "openharmony"
+                  ]
+            },
+            "node_modules/@rollup/rollup-win32-arm64-msvc": {
+                  "version": "4.52.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.0.tgz",
+                  "integrity": "sha512-YQugafP/rH0eOOHGjmNgDURrpYHrIX0yuojOI8bwCyXwxC9ZdTd3vYkmddPX0oHONLXu9Rb1dDmT0VNpjkzGGw==",
+                  "cpu": [
+                        "arm64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "win32"
+                  ]
+            },
+            "node_modules/@rollup/rollup-win32-ia32-msvc": {
+                  "version": "4.52.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.0.tgz",
+                  "integrity": "sha512-zYdUYhi3Qe2fndujBqL5FjAFzvNeLxtIqfzNEVKD1I7C37/chv1VxhscWSQHTNfjPCrBFQMnynwA3kpZpZ8w4A==",
+                  "cpu": [
+                        "ia32"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "win32"
+                  ]
+            },
+            "node_modules/@rollup/rollup-win32-x64-gnu": {
+                  "version": "4.52.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.0.tgz",
+                  "integrity": "sha512-fGk03kQylNaCOQ96HDMeT7E2n91EqvCDd3RwvT5k+xNdFCeMGnj5b5hEgTGrQuyidqSsD3zJDQ21QIaxXqTBJw==",
+                  "cpu": [
+                        "x64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "win32"
+                  ]
+            },
+            "node_modules/@rollup/rollup-win32-x64-msvc": {
+                  "version": "4.52.0",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.0.tgz",
+                  "integrity": "sha512-6iKDCVSIUQ8jPMoIV0OytRKniaYyy5EbY/RRydmLW8ZR3cEBhxbWl5ro0rkUNe0ef6sScvhbY79HrjRm8i3vDQ==",
+                  "cpu": [
+                        "x64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "win32"
+                  ]
+            },
+            "node_modules/@swc/core": {
+                  "version": "1.13.5",
+                  "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.13.5.tgz",
+                  "integrity": "sha512-WezcBo8a0Dg2rnR82zhwoR6aRNxeTGfK5QCD6TQ+kg3xx/zNT02s/0o+81h/3zhvFSB24NtqEr8FTw88O5W/JQ==",
+                  "dev": true,
+                  "hasInstallScript": true,
+                  "license": "Apache-2.0",
+                  "dependencies": {
+                        "@swc/counter": "^0.1.3",
+                        "@swc/types": "^0.1.24"
+                  },
+                  "engines": {
+                        "node": ">=10"
+                  },
+                  "funding": {
+                        "type": "opencollective",
+                        "url": "https://opencollective.com/swc"
+                  },
+                  "optionalDependencies": {
+                        "@swc/core-darwin-arm64": "1.13.5",
+                        "@swc/core-darwin-x64": "1.13.5",
+                        "@swc/core-linux-arm-gnueabihf": "1.13.5",
+                        "@swc/core-linux-arm64-gnu": "1.13.5",
+                        "@swc/core-linux-arm64-musl": "1.13.5",
+                        "@swc/core-linux-x64-gnu": "1.13.5",
+                        "@swc/core-linux-x64-musl": "1.13.5",
+                        "@swc/core-win32-arm64-msvc": "1.13.5",
+                        "@swc/core-win32-ia32-msvc": "1.13.5",
+                        "@swc/core-win32-x64-msvc": "1.13.5"
+                  },
+                  "peerDependencies": {
+                        "@swc/helpers": ">=0.5.17"
+                  },
+                  "peerDependenciesMeta": {
+                        "@swc/helpers": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@swc/core-darwin-arm64": {
+                  "version": "1.13.5",
+                  "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.13.5.tgz",
+                  "integrity": "sha512-lKNv7SujeXvKn16gvQqUQI5DdyY8v7xcoO3k06/FJbHJS90zEwZdQiMNRiqpYw/orU543tPaWgz7cIYWhbopiQ==",
+                  "cpu": [
+                        "arm64"
+                  ],
+                  "dev": true,
+                  "license": "Apache-2.0 AND MIT",
+                  "optional": true,
+                  "os": [
+                        "darwin"
+                  ],
+                  "engines": {
+                        "node": ">=10"
+                  }
+            },
+            "node_modules/@swc/core-darwin-x64": {
+                  "version": "1.13.5",
+                  "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.13.5.tgz",
+                  "integrity": "sha512-ILd38Fg/w23vHb0yVjlWvQBoE37ZJTdlLHa8LRCFDdX4WKfnVBiblsCU9ar4QTMNdeTBEX9iUF4IrbNWhaF1Ng==",
+                  "cpu": [
+                        "x64"
+                  ],
+                  "dev": true,
+                  "license": "Apache-2.0 AND MIT",
+                  "optional": true,
+                  "os": [
+                        "darwin"
+                  ],
+                  "engines": {
+                        "node": ">=10"
+                  }
+            },
+            "node_modules/@swc/core-linux-arm-gnueabihf": {
+                  "version": "1.13.5",
+                  "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.13.5.tgz",
+                  "integrity": "sha512-Q6eS3Pt8GLkXxqz9TAw+AUk9HpVJt8Uzm54MvPsqp2yuGmY0/sNaPPNVqctCX9fu/Nu8eaWUen0si6iEiCsazQ==",
+                  "cpu": [
+                        "arm"
+                  ],
+                  "dev": true,
+                  "license": "Apache-2.0",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ],
+                  "engines": {
+                        "node": ">=10"
+                  }
+            },
+            "node_modules/@swc/core-linux-arm64-gnu": {
+                  "version": "1.13.5",
+                  "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.13.5.tgz",
+                  "integrity": "sha512-aNDfeN+9af+y+M2MYfxCzCy/VDq7Z5YIbMqRI739o8Ganz6ST+27kjQFd8Y/57JN/hcnUEa9xqdS3XY7WaVtSw==",
+                  "cpu": [
+                        "arm64"
+                  ],
+                  "dev": true,
+                  "license": "Apache-2.0 AND MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ],
+                  "engines": {
+                        "node": ">=10"
+                  }
+            },
+            "node_modules/@swc/core-linux-arm64-musl": {
+                  "version": "1.13.5",
+                  "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.13.5.tgz",
+                  "integrity": "sha512-9+ZxFN5GJag4CnYnq6apKTnnezpfJhCumyz0504/JbHLo+Ue+ZtJnf3RhyA9W9TINtLE0bC4hKpWi8ZKoETyOQ==",
+                  "cpu": [
+                        "arm64"
+                  ],
+                  "dev": true,
+                  "license": "Apache-2.0 AND MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ],
+                  "engines": {
+                        "node": ">=10"
+                  }
+            },
+            "node_modules/@swc/core-linux-x64-gnu": {
+                  "version": "1.13.5",
+                  "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.13.5.tgz",
+                  "integrity": "sha512-WD530qvHrki8Ywt/PloKUjaRKgstQqNGvmZl54g06kA+hqtSE2FTG9gngXr3UJxYu/cNAjJYiBifm7+w4nbHbA==",
+                  "cpu": [
+                        "x64"
+                  ],
+                  "dev": true,
+                  "license": "Apache-2.0 AND MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ],
+                  "engines": {
+                        "node": ">=10"
+                  }
+            },
+            "node_modules/@swc/core-linux-x64-musl": {
+                  "version": "1.13.5",
+                  "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.13.5.tgz",
+                  "integrity": "sha512-Luj8y4OFYx4DHNQTWjdIuKTq2f5k6uSXICqx+FSabnXptaOBAbJHNbHT/06JZh6NRUouaf0mYXN0mcsqvkhd7Q==",
+                  "cpu": [
+                        "x64"
+                  ],
+                  "dev": true,
+                  "license": "Apache-2.0 AND MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ],
+                  "engines": {
+                        "node": ">=10"
+                  }
+            },
+            "node_modules/@swc/core-win32-arm64-msvc": {
+                  "version": "1.13.5",
+                  "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.13.5.tgz",
+                  "integrity": "sha512-cZ6UpumhF9SDJvv4DA2fo9WIzlNFuKSkZpZmPG1c+4PFSEMy5DFOjBSllCvnqihCabzXzpn6ykCwBmHpy31vQw==",
+                  "cpu": [
+                        "arm64"
+                  ],
+                  "dev": true,
+                  "license": "Apache-2.0 AND MIT",
+                  "optional": true,
+                  "os": [
+                        "win32"
+                  ],
+                  "engines": {
+                        "node": ">=10"
+                  }
+            },
+            "node_modules/@swc/core-win32-ia32-msvc": {
+                  "version": "1.13.5",
+                  "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.13.5.tgz",
+                  "integrity": "sha512-C5Yi/xIikrFUzZcyGj9L3RpKljFvKiDMtyDzPKzlsDrKIw2EYY+bF88gB6oGY5RGmv4DAX8dbnpRAqgFD0FMEw==",
+                  "cpu": [
+                        "ia32"
+                  ],
+                  "dev": true,
+                  "license": "Apache-2.0 AND MIT",
+                  "optional": true,
+                  "os": [
+                        "win32"
+                  ],
+                  "engines": {
+                        "node": ">=10"
+                  }
+            },
+            "node_modules/@swc/core-win32-x64-msvc": {
+                  "version": "1.13.5",
+                  "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.13.5.tgz",
+                  "integrity": "sha512-YrKdMVxbYmlfybCSbRtrilc6UA8GF5aPmGKBdPvjrarvsmf4i7ZHGCEnLtfOMd3Lwbs2WUZq3WdMbozYeLU93Q==",
+                  "cpu": [
+                        "x64"
+                  ],
+                  "dev": true,
+                  "license": "Apache-2.0 AND MIT",
+                  "optional": true,
+                  "os": [
+                        "win32"
+                  ],
+                  "engines": {
+                        "node": ">=10"
+                  }
+            },
+            "node_modules/@swc/counter": {
+                  "version": "0.1.3",
+                  "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+                  "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+                  "dev": true,
+                  "license": "Apache-2.0"
+            },
+            "node_modules/@swc/types": {
+                  "version": "0.1.25",
+                  "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.25.tgz",
+                  "integrity": "sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==",
+                  "dev": true,
+                  "license": "Apache-2.0",
+                  "dependencies": {
+                        "@swc/counter": "^0.1.3"
+                  }
+            },
+            "node_modules/@types/d3-array": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+                  "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+                  "license": "MIT"
+            },
+            "node_modules/@types/d3-color": {
+                  "version": "3.1.3",
+                  "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+                  "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+                  "license": "MIT"
+            },
+            "node_modules/@types/d3-ease": {
+                  "version": "3.0.2",
+                  "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+                  "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+                  "license": "MIT"
+            },
+            "node_modules/@types/d3-interpolate": {
+                  "version": "3.0.4",
+                  "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+                  "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@types/d3-color": "*"
+                  }
+            },
+            "node_modules/@types/d3-path": {
+                  "version": "3.1.1",
+                  "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+                  "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+                  "license": "MIT"
+            },
+            "node_modules/@types/d3-scale": {
+                  "version": "4.0.9",
+                  "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+                  "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@types/d3-time": "*"
+                  }
+            },
+            "node_modules/@types/d3-shape": {
+                  "version": "3.1.7",
+                  "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+                  "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@types/d3-path": "*"
+                  }
+            },
+            "node_modules/@types/d3-time": {
+                  "version": "3.0.4",
+                  "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+                  "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+                  "license": "MIT"
+            },
+            "node_modules/@types/d3-timer": {
+                  "version": "3.0.2",
+                  "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+                  "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+                  "license": "MIT"
+            },
+            "node_modules/@types/estree": {
+                  "version": "1.0.8",
+                  "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+                  "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+                  "dev": true,
+                  "license": "MIT"
+            },
+            "node_modules/@types/node": {
+                  "version": "20.19.17",
+                  "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.17.tgz",
+                  "integrity": "sha512-gfehUI8N1z92kygssiuWvLiwcbOB3IRktR6hTDgJlXMYh5OvkPSRmgfoBUmfZt+vhwJtX7v1Yw4KvvAf7c5QKQ==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "undici-types": "~6.21.0"
+                  }
+            },
+            "node_modules/@vitejs/plugin-react-swc": {
+                  "version": "3.11.0",
+                  "resolved": "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-3.11.0.tgz",
+                  "integrity": "sha512-YTJCGFdNMHCMfjODYtxRNVAYmTWQ1Lb8PulP/2/f/oEEtglw8oKxKIZmmRkyXrVrHfsKOaVkAc3NT9/dMutO5w==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "@rolldown/pluginutils": "1.0.0-beta.27",
+                        "@swc/core": "^1.12.11"
+                  },
+                  "peerDependencies": {
+                        "vite": "^4 || ^5 || ^6 || ^7"
+                  }
+            },
+            "node_modules/aria-hidden": {
+                  "version": "1.2.6",
+                  "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+                  "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "tslib": "^2.0.0"
+                  },
+                  "engines": {
+                        "node": ">=10"
+                  }
+            },
+            "node_modules/class-variance-authority": {
+                  "version": "0.7.1",
+                  "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+                  "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+                  "license": "Apache-2.0",
+                  "dependencies": {
+                        "clsx": "^2.1.1"
+                  },
+                  "funding": {
+                        "url": "https://polar.sh/cva"
+                  }
+            },
+            "node_modules/clsx": {
+                  "version": "2.1.1",
+                  "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+                  "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=6"
+                  }
+            },
+            "node_modules/cmdk": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+                  "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/react-compose-refs": "^1.1.1",
+                        "@radix-ui/react-dialog": "^1.1.6",
+                        "@radix-ui/react-id": "^1.1.0",
+                        "@radix-ui/react-primitive": "^2.0.2"
+                  },
+                  "peerDependencies": {
+                        "react": "^18 || ^19 || ^19.0.0-rc",
+                        "react-dom": "^18 || ^19 || ^19.0.0-rc"
+                  }
+            },
+            "node_modules/csstype": {
+                  "version": "3.1.3",
+                  "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+                  "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+                  "license": "MIT"
+            },
+            "node_modules/d3-array": {
+                  "version": "3.2.4",
+                  "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+                  "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+                  "license": "ISC",
+                  "dependencies": {
+                        "internmap": "1 - 2"
+                  },
+                  "engines": {
+                        "node": ">=12"
+                  }
+            },
+            "node_modules/d3-color": {
+                  "version": "3.1.0",
+                  "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+                  "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+                  "license": "ISC",
+                  "engines": {
+                        "node": ">=12"
+                  }
+            },
+            "node_modules/d3-ease": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+                  "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+                  "license": "BSD-3-Clause",
+                  "engines": {
+                        "node": ">=12"
+                  }
+            },
+            "node_modules/d3-format": {
+                  "version": "3.1.0",
+                  "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+                  "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+                  "license": "ISC",
+                  "engines": {
+                        "node": ">=12"
+                  }
+            },
+            "node_modules/d3-interpolate": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+                  "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+                  "license": "ISC",
+                  "dependencies": {
+                        "d3-color": "1 - 3"
+                  },
+                  "engines": {
+                        "node": ">=12"
+                  }
+            },
+            "node_modules/d3-path": {
+                  "version": "3.1.0",
+                  "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+                  "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+                  "license": "ISC",
+                  "engines": {
+                        "node": ">=12"
+                  }
+            },
+            "node_modules/d3-scale": {
+                  "version": "4.0.2",
+                  "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+                  "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+                  "license": "ISC",
+                  "dependencies": {
+                        "d3-array": "2.10.0 - 3",
+                        "d3-format": "1 - 3",
+                        "d3-interpolate": "1.2.0 - 3",
+                        "d3-time": "2.1.1 - 3",
+                        "d3-time-format": "2 - 4"
+                  },
+                  "engines": {
+                        "node": ">=12"
+                  }
+            },
+            "node_modules/d3-shape": {
+                  "version": "3.2.0",
+                  "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+                  "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+                  "license": "ISC",
+                  "dependencies": {
+                        "d3-path": "^3.1.0"
+                  },
+                  "engines": {
+                        "node": ">=12"
+                  }
+            },
+            "node_modules/d3-time": {
+                  "version": "3.1.0",
+                  "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+                  "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+                  "license": "ISC",
+                  "dependencies": {
+                        "d3-array": "2 - 3"
+                  },
+                  "engines": {
+                        "node": ">=12"
+                  }
+            },
+            "node_modules/d3-time-format": {
+                  "version": "4.1.0",
+                  "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+                  "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+                  "license": "ISC",
+                  "dependencies": {
+                        "d3-time": "1 - 3"
+                  },
+                  "engines": {
+                        "node": ">=12"
+                  }
+            },
+            "node_modules/d3-timer": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+                  "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+                  "license": "ISC",
+                  "engines": {
+                        "node": ">=12"
+                  }
+            },
+            "node_modules/date-fns": {
+                  "version": "3.6.0",
+                  "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+                  "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+                  "license": "MIT",
+                  "peer": true,
+                  "funding": {
+                        "type": "github",
+                        "url": "https://github.com/sponsors/kossnocorp"
+                  }
+            },
+            "node_modules/decimal.js-light": {
+                  "version": "2.5.1",
+                  "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+                  "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+                  "license": "MIT"
+            },
+            "node_modules/detect-node-es": {
+                  "version": "1.1.0",
+                  "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+                  "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+                  "license": "MIT"
+            },
+            "node_modules/dom-helpers": {
+                  "version": "5.2.1",
+                  "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+                  "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@babel/runtime": "^7.8.7",
+                        "csstype": "^3.0.2"
+                  }
+            },
+            "node_modules/embla-carousel": {
+                  "version": "8.6.0",
+                  "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
+                  "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
+                  "license": "MIT"
+            },
+            "node_modules/embla-carousel-react": {
+                  "version": "8.6.0",
+                  "resolved": "https://registry.npmjs.org/embla-carousel-react/-/embla-carousel-react-8.6.0.tgz",
+                  "integrity": "sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "embla-carousel": "8.6.0",
+                        "embla-carousel-reactive-utils": "8.6.0"
+                  },
+                  "peerDependencies": {
+                        "react": "^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+                  }
+            },
+            "node_modules/embla-carousel-reactive-utils": {
+                  "version": "8.6.0",
+                  "resolved": "https://registry.npmjs.org/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.6.0.tgz",
+                  "integrity": "sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A==",
+                  "license": "MIT",
+                  "peerDependencies": {
+                        "embla-carousel": "8.6.0"
+                  }
+            },
+            "node_modules/esbuild": {
+                  "version": "0.25.10",
+                  "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
+                  "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
+                  "dev": true,
+                  "hasInstallScript": true,
+                  "license": "MIT",
+                  "bin": {
+                        "esbuild": "bin/esbuild"
+                  },
+                  "engines": {
+                        "node": ">=18"
+                  },
+                  "optionalDependencies": {
+                        "@esbuild/aix-ppc64": "0.25.10",
+                        "@esbuild/android-arm": "0.25.10",
+                        "@esbuild/android-arm64": "0.25.10",
+                        "@esbuild/android-x64": "0.25.10",
+                        "@esbuild/darwin-arm64": "0.25.10",
+                        "@esbuild/darwin-x64": "0.25.10",
+                        "@esbuild/freebsd-arm64": "0.25.10",
+                        "@esbuild/freebsd-x64": "0.25.10",
+                        "@esbuild/linux-arm": "0.25.10",
+                        "@esbuild/linux-arm64": "0.25.10",
+                        "@esbuild/linux-ia32": "0.25.10",
+                        "@esbuild/linux-loong64": "0.25.10",
+                        "@esbuild/linux-mips64el": "0.25.10",
+                        "@esbuild/linux-ppc64": "0.25.10",
+                        "@esbuild/linux-riscv64": "0.25.10",
+                        "@esbuild/linux-s390x": "0.25.10",
+                        "@esbuild/linux-x64": "0.25.10",
+                        "@esbuild/netbsd-arm64": "0.25.10",
+                        "@esbuild/netbsd-x64": "0.25.10",
+                        "@esbuild/openbsd-arm64": "0.25.10",
+                        "@esbuild/openbsd-x64": "0.25.10",
+                        "@esbuild/openharmony-arm64": "0.25.10",
+                        "@esbuild/sunos-x64": "0.25.10",
+                        "@esbuild/win32-arm64": "0.25.10",
+                        "@esbuild/win32-ia32": "0.25.10",
+                        "@esbuild/win32-x64": "0.25.10"
+                  }
+            },
+            "node_modules/eventemitter3": {
+                  "version": "4.0.7",
+                  "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+                  "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+                  "license": "MIT"
+            },
+            "node_modules/fast-equals": {
+                  "version": "5.2.2",
+                  "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.2.2.tgz",
+                  "integrity": "sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==",
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=6.0.0"
+                  }
+            },
+            "node_modules/fdir": {
+                  "version": "6.5.0",
+                  "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+                  "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=12.0.0"
+                  },
+                  "peerDependencies": {
+                        "picomatch": "^3 || ^4"
+                  },
+                  "peerDependenciesMeta": {
+                        "picomatch": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/fsevents": {
+                  "version": "2.3.3",
+                  "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+                  "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+                  "dev": true,
+                  "hasInstallScript": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "darwin"
+                  ],
+                  "engines": {
+                        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+                  }
+            },
+            "node_modules/get-nonce": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+                  "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=6"
+                  }
+            },
+            "node_modules/input-otp": {
+                  "version": "1.4.2",
+                  "resolved": "https://registry.npmjs.org/input-otp/-/input-otp-1.4.2.tgz",
+                  "integrity": "sha512-l3jWwYNvrEa6NTCt7BECfCm48GvwuZzkoeG3gBL2w4CHeOXW3eKFmf9UNYkNfYc3mxMrthMnxjIE07MT0zLBQA==",
+                  "license": "MIT",
+                  "peerDependencies": {
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
+                  }
+            },
+            "node_modules/internmap": {
+                  "version": "2.0.3",
+                  "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+                  "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+                  "license": "ISC",
+                  "engines": {
+                        "node": ">=12"
+                  }
+            },
+            "node_modules/js-tokens": {
+                  "version": "4.0.0",
+                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+                  "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+                  "license": "MIT"
+            },
+            "node_modules/lodash": {
+                  "version": "4.17.21",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+                  "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+                  "license": "MIT"
+            },
+            "node_modules/loose-envify": {
+                  "version": "1.4.0",
+                  "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+                  "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "js-tokens": "^3.0.0 || ^4.0.0"
+                  },
+                  "bin": {
+                        "loose-envify": "cli.js"
+                  }
+            },
+            "node_modules/lucide-react": {
+                  "version": "0.487.0",
+                  "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.487.0.tgz",
+                  "integrity": "sha512-aKqhOQ+YmFnwq8dWgGjOuLc8V1R9/c/yOd+zDY4+ohsR2Jo05lSGc3WsstYPIzcTpeosN7LoCkLReUUITvaIvw==",
+                  "license": "ISC",
+                  "peerDependencies": {
+                        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+                  }
+            },
+            "node_modules/nanoid": {
+                  "version": "3.3.11",
+                  "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+                  "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+                  "dev": true,
+                  "funding": [
+                        {
+                              "type": "github",
+                              "url": "https://github.com/sponsors/ai"
+                        }
+                  ],
+                  "license": "MIT",
+                  "bin": {
+                        "nanoid": "bin/nanoid.cjs"
+                  },
+                  "engines": {
+                        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+                  }
+            },
+            "node_modules/next-themes": {
+                  "version": "0.4.6",
+                  "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+                  "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+                  "license": "MIT",
+                  "peerDependencies": {
+                        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+                  }
+            },
+            "node_modules/object-assign": {
+                  "version": "4.1.1",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                  "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=0.10.0"
+                  }
+            },
+            "node_modules/picocolors": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+                  "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+                  "dev": true,
+                  "license": "ISC"
+            },
+            "node_modules/picomatch": {
+                  "version": "4.0.3",
+                  "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+                  "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=12"
+                  },
+                  "funding": {
+                        "url": "https://github.com/sponsors/jonschlinkert"
+                  }
+            },
+            "node_modules/postcss": {
+                  "version": "8.5.6",
+                  "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+                  "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+                  "dev": true,
+                  "funding": [
+                        {
+                              "type": "opencollective",
+                              "url": "https://opencollective.com/postcss/"
+                        },
+                        {
+                              "type": "tidelift",
+                              "url": "https://tidelift.com/funding/github/npm/postcss"
+                        },
+                        {
+                              "type": "github",
+                              "url": "https://github.com/sponsors/ai"
+                        }
+                  ],
+                  "license": "MIT",
+                  "dependencies": {
+                        "nanoid": "^3.3.11",
+                        "picocolors": "^1.1.1",
+                        "source-map-js": "^1.2.1"
+                  },
+                  "engines": {
+                        "node": "^10 || ^12 || >=14"
+                  }
+            },
+            "node_modules/prop-types": {
+                  "version": "15.8.1",
+                  "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+                  "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "loose-envify": "^1.4.0",
+                        "object-assign": "^4.1.1",
+                        "react-is": "^16.13.1"
+                  }
+            },
+            "node_modules/prop-types/node_modules/react-is": {
+                  "version": "16.13.1",
+                  "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+                  "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+                  "license": "MIT"
+            },
+            "node_modules/react": {
+                  "version": "18.3.1",
+                  "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+                  "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "loose-envify": "^1.1.0"
+                  },
+                  "engines": {
+                        "node": ">=0.10.0"
+                  }
+            },
+            "node_modules/react-day-picker": {
+                  "version": "8.10.1",
+                  "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.10.1.tgz",
+                  "integrity": "sha512-TMx7fNbhLk15eqcMt+7Z7S2KF7mfTId/XJDjKE8f+IUcFn0l08/kI4FiYTL/0yuOLmEcbR4Fwe3GJf/NiiMnPA==",
+                  "license": "MIT",
+                  "funding": {
+                        "type": "individual",
+                        "url": "https://github.com/sponsors/gpbl"
+                  },
+                  "peerDependencies": {
+                        "date-fns": "^2.28.0 || ^3.0.0",
+                        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+                  }
+            },
+            "node_modules/react-dom": {
+                  "version": "18.3.1",
+                  "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+                  "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "loose-envify": "^1.1.0",
+                        "scheduler": "^0.23.2"
+                  },
+                  "peerDependencies": {
+                        "react": "^18.3.1"
+                  }
+            },
+            "node_modules/react-hook-form": {
+                  "version": "7.63.0",
+                  "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.63.0.tgz",
+                  "integrity": "sha512-ZwueDMvUeucovM2VjkCf7zIHcs1aAlDimZu2Hvel5C5907gUzMpm4xCrQXtRzCvsBqFjonB4m3x4LzCFI1ZKWA==",
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=18.0.0"
+                  },
+                  "funding": {
+                        "type": "opencollective",
+                        "url": "https://opencollective.com/react-hook-form"
+                  },
+                  "peerDependencies": {
+                        "react": "^16.8.0 || ^17 || ^18 || ^19"
+                  }
+            },
+            "node_modules/react-is": {
+                  "version": "18.3.1",
+                  "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+                  "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+                  "license": "MIT"
+            },
+            "node_modules/react-remove-scroll": {
+                  "version": "2.7.1",
+                  "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.1.tgz",
+                  "integrity": "sha512-HpMh8+oahmIdOuS5aFKKY6Pyog+FNaZV/XyJOq7b4YFwsFHe5yYfdbIalI4k3vU2nSDql7YskmUseHsRrJqIPA==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "react-remove-scroll-bar": "^2.3.7",
+                        "react-style-singleton": "^2.2.3",
+                        "tslib": "^2.1.0",
+                        "use-callback-ref": "^1.3.3",
+                        "use-sidecar": "^1.1.3"
+                  },
+                  "engines": {
+                        "node": ">=10"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/react-remove-scroll-bar": {
+                  "version": "2.3.8",
+                  "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+                  "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "react-style-singleton": "^2.2.2",
+                        "tslib": "^2.0.0"
+                  },
+                  "engines": {
+                        "node": ">=10"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/react-resizable-panels": {
+                  "version": "2.1.9",
+                  "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-2.1.9.tgz",
+                  "integrity": "sha512-z77+X08YDIrgAes4jl8xhnUu1LNIRp4+E7cv4xHmLOxxUPO/ML7PSrE813b90vj7xvQ1lcf7g2uA9GeMZonjhQ==",
+                  "license": "MIT",
+                  "peerDependencies": {
+                        "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+                        "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+                  }
+            },
+            "node_modules/react-smooth": {
+                  "version": "4.0.4",
+                  "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+                  "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "fast-equals": "^5.0.1",
+                        "prop-types": "^15.8.1",
+                        "react-transition-group": "^4.4.5"
+                  },
+                  "peerDependencies": {
+                        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+                  }
+            },
+            "node_modules/react-style-singleton": {
+                  "version": "2.2.3",
+                  "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+                  "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "get-nonce": "^1.0.0",
+                        "tslib": "^2.0.0"
+                  },
+                  "engines": {
+                        "node": ">=10"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/react-transition-group": {
+                  "version": "4.4.5",
+                  "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+                  "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+                  "license": "BSD-3-Clause",
+                  "dependencies": {
+                        "@babel/runtime": "^7.5.5",
+                        "dom-helpers": "^5.0.1",
+                        "loose-envify": "^1.4.0",
+                        "prop-types": "^15.6.2"
+                  },
+                  "peerDependencies": {
+                        "react": ">=16.6.0",
+                        "react-dom": ">=16.6.0"
+                  }
+            },
+            "node_modules/recharts": {
+                  "version": "2.15.4",
+                  "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
+                  "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "clsx": "^2.0.0",
+                        "eventemitter3": "^4.0.1",
+                        "lodash": "^4.17.21",
+                        "react-is": "^18.3.1",
+                        "react-smooth": "^4.0.4",
+                        "recharts-scale": "^0.4.4",
+                        "tiny-invariant": "^1.3.1",
+                        "victory-vendor": "^36.6.8"
+                  },
+                  "engines": {
+                        "node": ">=14"
+                  },
+                  "peerDependencies": {
+                        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+                  }
+            },
+            "node_modules/recharts-scale": {
+                  "version": "0.4.5",
+                  "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+                  "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "decimal.js-light": "^2.4.1"
+                  }
+            },
+            "node_modules/rollup": {
+                  "version": "4.52.0",
+                  "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.0.tgz",
+                  "integrity": "sha512-+IuescNkTJQgX7AkIDtITipZdIGcWF0pnVvZTWStiazUmcGA2ag8dfg0urest2XlXUi9kuhfQ+qmdc5Stc3z7g==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "@types/estree": "1.0.8"
+                  },
+                  "bin": {
+                        "rollup": "dist/bin/rollup"
+                  },
+                  "engines": {
+                        "node": ">=18.0.0",
+                        "npm": ">=8.0.0"
+                  },
+                  "optionalDependencies": {
+                        "@rollup/rollup-android-arm-eabi": "4.52.0",
+                        "@rollup/rollup-android-arm64": "4.52.0",
+                        "@rollup/rollup-darwin-arm64": "4.52.0",
+                        "@rollup/rollup-darwin-x64": "4.52.0",
+                        "@rollup/rollup-freebsd-arm64": "4.52.0",
+                        "@rollup/rollup-freebsd-x64": "4.52.0",
+                        "@rollup/rollup-linux-arm-gnueabihf": "4.52.0",
+                        "@rollup/rollup-linux-arm-musleabihf": "4.52.0",
+                        "@rollup/rollup-linux-arm64-gnu": "4.52.0",
+                        "@rollup/rollup-linux-arm64-musl": "4.52.0",
+                        "@rollup/rollup-linux-loong64-gnu": "4.52.0",
+                        "@rollup/rollup-linux-ppc64-gnu": "4.52.0",
+                        "@rollup/rollup-linux-riscv64-gnu": "4.52.0",
+                        "@rollup/rollup-linux-riscv64-musl": "4.52.0",
+                        "@rollup/rollup-linux-s390x-gnu": "4.52.0",
+                        "@rollup/rollup-linux-x64-gnu": "4.52.0",
+                        "@rollup/rollup-linux-x64-musl": "4.52.0",
+                        "@rollup/rollup-openharmony-arm64": "4.52.0",
+                        "@rollup/rollup-win32-arm64-msvc": "4.52.0",
+                        "@rollup/rollup-win32-ia32-msvc": "4.52.0",
+                        "@rollup/rollup-win32-x64-gnu": "4.52.0",
+                        "@rollup/rollup-win32-x64-msvc": "4.52.0",
+                        "fsevents": "~2.3.2"
+                  }
+            },
+            "node_modules/scheduler": {
+                  "version": "0.23.2",
+                  "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+                  "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "loose-envify": "^1.1.0"
+                  }
+            },
+            "node_modules/sonner": {
+                  "version": "2.0.7",
+                  "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+                  "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+                  "license": "MIT",
+                  "peerDependencies": {
+                        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+                        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+                  }
+            },
+            "node_modules/source-map-js": {
+                  "version": "1.2.1",
+                  "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+                  "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+                  "dev": true,
+                  "license": "BSD-3-Clause",
+                  "engines": {
+                        "node": ">=0.10.0"
+                  }
+            },
+            "node_modules/tailwind-merge": {
+                  "version": "3.3.1",
+                  "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.1.tgz",
+                  "integrity": "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==",
+                  "license": "MIT",
+                  "funding": {
+                        "type": "github",
+                        "url": "https://github.com/sponsors/dcastil"
+                  }
+            },
+            "node_modules/tiny-invariant": {
+                  "version": "1.3.3",
+                  "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+                  "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+                  "license": "MIT"
+            },
+            "node_modules/tinyglobby": {
+                  "version": "0.2.15",
+                  "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+                  "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "fdir": "^6.5.0",
+                        "picomatch": "^4.0.3"
+                  },
+                  "engines": {
+                        "node": ">=12.0.0"
+                  },
+                  "funding": {
+                        "url": "https://github.com/sponsors/SuperchupuDev"
+                  }
+            },
+            "node_modules/tslib": {
+                  "version": "2.8.1",
+                  "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+                  "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+                  "license": "0BSD"
+            },
+            "node_modules/undici-types": {
+                  "version": "6.21.0",
+                  "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+                  "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+                  "dev": true,
+                  "license": "MIT"
+            },
+            "node_modules/use-callback-ref": {
+                  "version": "1.3.3",
+                  "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+                  "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "tslib": "^2.0.0"
+                  },
+                  "engines": {
+                        "node": ">=10"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/use-sidecar": {
+                  "version": "1.1.3",
+                  "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+                  "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "detect-node-es": "^1.1.0",
+                        "tslib": "^2.0.0"
+                  },
+                  "engines": {
+                        "node": ">=10"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/use-sync-external-store": {
+                  "version": "1.5.0",
+                  "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+                  "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+                  "license": "MIT",
+                  "peerDependencies": {
+                        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+                  }
+            },
+            "node_modules/vaul": {
+                  "version": "1.1.2",
+                  "resolved": "https://registry.npmjs.org/vaul/-/vaul-1.1.2.tgz",
+                  "integrity": "sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/react-dialog": "^1.1.1"
+                  },
+                  "peerDependencies": {
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
+                  }
+            },
+            "node_modules/victory-vendor": {
+                  "version": "36.9.2",
+                  "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+                  "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+                  "license": "MIT AND ISC",
+                  "dependencies": {
+                        "@types/d3-array": "^3.0.3",
+                        "@types/d3-ease": "^3.0.0",
+                        "@types/d3-interpolate": "^3.0.1",
+                        "@types/d3-scale": "^4.0.2",
+                        "@types/d3-shape": "^3.1.0",
+                        "@types/d3-time": "^3.0.0",
+                        "@types/d3-timer": "^3.0.0",
+                        "d3-array": "^3.1.6",
+                        "d3-ease": "^3.0.1",
+                        "d3-interpolate": "^3.0.1",
+                        "d3-scale": "^4.0.2",
+                        "d3-shape": "^3.1.0",
+                        "d3-time": "^3.0.0",
+                        "d3-timer": "^3.0.1"
+                  }
+            },
+            "node_modules/vite": {
+                  "version": "6.3.5",
+                  "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
+                  "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "esbuild": "^0.25.0",
+                        "fdir": "^6.4.4",
+                        "picomatch": "^4.0.2",
+                        "postcss": "^8.5.3",
+                        "rollup": "^4.34.9",
+                        "tinyglobby": "^0.2.13"
+                  },
+                  "bin": {
+                        "vite": "bin/vite.js"
+                  },
+                  "engines": {
+                        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+                  },
+                  "funding": {
+                        "url": "https://github.com/vitejs/vite?sponsor=1"
+                  },
+                  "optionalDependencies": {
+                        "fsevents": "~2.3.3"
+                  },
+                  "peerDependencies": {
+                        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+                        "jiti": ">=1.21.0",
+                        "less": "*",
+                        "lightningcss": "^1.21.0",
+                        "sass": "*",
+                        "sass-embedded": "*",
+                        "stylus": "*",
+                        "sugarss": "*",
+                        "terser": "^5.16.0",
+                        "tsx": "^4.8.1",
+                        "yaml": "^2.4.2"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/node": {
+                              "optional": true
+                        },
+                        "jiti": {
+                              "optional": true
+                        },
+                        "less": {
+                              "optional": true
+                        },
+                        "lightningcss": {
+                              "optional": true
+                        },
+                        "sass": {
+                              "optional": true
+                        },
+                        "sass-embedded": {
+                              "optional": true
+                        },
+                        "stylus": {
+                              "optional": true
+                        },
+                        "sugarss": {
+                              "optional": true
+                        },
+                        "terser": {
+                              "optional": true
+                        },
+                        "tsx": {
+                              "optional": true
+                        },
+                        "yaml": {
+                              "optional": true
+                        }
+                  }
+            }
+      }
+}

--- a/figma/src/App.tsx
+++ b/figma/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, createContext, useContext } from 'react';
+import React, { useState, createContext, useContext, useCallback, useMemo } from 'react';
 import { Landing } from './components/pages/Landing';
 import { Analyze } from './components/pages/Analyze';
 import { Select } from './components/pages/Select';
@@ -6,20 +6,39 @@ import { Export } from './components/pages/Export';
 import { Jobs } from './components/pages/Jobs';
 import { Result } from './components/pages/Result';
 import { Topbar } from './components/organisms/Topbar';
+import { fetchRepositoryTree } from './lib/api';
+import { ArtifactFile, JobState, Page, RepoData, Theme, TreeItem } from './lib/types';
 
-type Theme = 'light' | 'dark';
 type Language = 'ru' | 'en';
-type Page = 'landing' | 'analyze' | 'select' | 'export' | 'jobs' | 'result';
 
 interface AppContextType {
   theme: Theme;
   language: Language;
   currentPage: Page;
-  repoData: any;
+  repoData: RepoData | null;
+  treeItems: TreeItem[];
+  treeSource: { owner: string; repo: string; ref: string } | null;
+  treeLoading: boolean;
+  treeError: string | null;
+  selectedPaths: string[];
+  includeMasks: string[];
+  excludeMasks: string[];
+  currentJob: JobState | null;
+  artifacts: ArtifactFile[];
+  artifactsExpiresAt: string | null;
   setTheme: (theme: Theme) => void;
   setLanguage: (language: Language) => void;
   setCurrentPage: (page: Page) => void;
-  setRepoData: (data: any) => void;
+  setRepoData: React.Dispatch<React.SetStateAction<RepoData | null>>;
+  setTreeItems: React.Dispatch<React.SetStateAction<TreeItem[]>>;
+  setTreeSource: React.Dispatch<React.SetStateAction<{ owner: string; repo: string; ref: string } | null>>;
+  setSelectedPaths: React.Dispatch<React.SetStateAction<string[]>>;
+  setIncludeMasks: React.Dispatch<React.SetStateAction<string[]>>;
+  setExcludeMasks: React.Dispatch<React.SetStateAction<string[]>>;
+  setCurrentJob: React.Dispatch<React.SetStateAction<JobState | null>>;
+  setArtifacts: React.Dispatch<React.SetStateAction<ArtifactFile[]>>;
+  setArtifactsExpiresAt: React.Dispatch<React.SetStateAction<string | null>>;
+  loadTree: (owner: string, repo: string, ref: string, force?: boolean) => Promise<void>;
 }
 
 const AppContext = createContext<AppContextType | null>(null);
@@ -36,18 +55,88 @@ export default function App() {
   const [theme, setTheme] = useState<Theme>('light');
   const [language, setLanguage] = useState<Language>('ru');
   const [currentPage, setCurrentPage] = useState<Page>('landing');
-  const [repoData, setRepoData] = useState<any>(null);
+  const [repoData, setRepoData] = useState<RepoData | null>(null);
+  const [treeItems, setTreeItems] = useState<TreeItem[]>([]);
+  const [treeSource, setTreeSource] = useState<{ owner: string; repo: string; ref: string } | null>(null);
+  const [treeLoading, setTreeLoading] = useState<boolean>(false);
+  const [treeError, setTreeError] = useState<string | null>(null);
+  const [selectedPaths, setSelectedPaths] = useState<string[]>([]);
+  const [includeMasks, setIncludeMasks] = useState<string[]>(['**/*.ts', '**/*.tsx', 'README.md']);
+  const [excludeMasks, setExcludeMasks] = useState<string[]>(['node_modules/**', '.next/**', 'dist/**', 'coverage/**']);
+  const [currentJob, setCurrentJob] = useState<JobState | null>(null);
+  const [artifacts, setArtifacts] = useState<ArtifactFile[]>([]);
+  const [artifactsExpiresAt, setArtifactsExpiresAt] = useState<string | null>(null);
 
-  const contextValue: AppContextType = {
-    theme,
-    language,
-    currentPage,
-    repoData,
-    setTheme,
-    setLanguage,
-    setCurrentPage,
-    setRepoData,
-  };
+  const loadTree = useCallback(
+    async (owner: string, repo: string, ref: string, force: boolean = false) => {
+      if (!force && treeSource && treeSource.owner === owner && treeSource.repo === repo && treeSource.ref === ref && treeItems.length > 0) {
+        return;
+      }
+      setTreeLoading(true);
+      setTreeError(null);
+      try {
+        const response = await fetchRepositoryTree(owner, repo, ref);
+        setTreeItems(response.items);
+        setTreeSource({ owner, repo, ref });
+      } catch (error) {
+        setTreeItems([]);
+        setTreeError(error instanceof Error ? error.message : 'Failed to load repository tree');
+        throw error;
+      } finally {
+        setTreeLoading(false);
+      }
+    },
+    [treeItems.length, treeSource]
+  );
+
+  const contextValue = useMemo<AppContextType>(
+    () => ({
+      theme,
+      language,
+      currentPage,
+      repoData,
+      treeItems,
+      treeSource,
+      treeLoading,
+      treeError,
+      selectedPaths,
+      includeMasks,
+      excludeMasks,
+      currentJob,
+      artifacts,
+      artifactsExpiresAt,
+      setTheme,
+      setLanguage,
+      setCurrentPage,
+      setRepoData,
+      setTreeItems,
+      setTreeSource,
+      setSelectedPaths,
+      setIncludeMasks,
+      setExcludeMasks,
+      setCurrentJob,
+      setArtifacts,
+      setArtifactsExpiresAt,
+      loadTree,
+    }),
+    [
+      theme,
+      language,
+      currentPage,
+      repoData,
+      treeItems,
+      treeSource,
+      treeLoading,
+      treeError,
+      selectedPaths,
+      includeMasks,
+      excludeMasks,
+      currentJob,
+      artifacts,
+      artifactsExpiresAt,
+      loadTree,
+    ]
+  );
 
   const renderCurrentPage = () => {
     switch (currentPage) {

--- a/figma/src/components/molecules/ArtifactsList.tsx
+++ b/figma/src/components/molecules/ArtifactsList.tsx
@@ -4,17 +4,11 @@ import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
 import { Button } from '../ui/button';
 import { Badge } from '../ui/badge';
 import { Download, FileArchive, FileText, File } from 'lucide-react';
-
-interface Artifact {
-  id: string;
-  name: string;
-  type: 'zip' | 'md' | 'txt';
-  size: string;
-  url: string;
-}
+import { formatBytes } from '../../lib/utils';
+import { ArtifactFile } from '../../lib/types';
 
 interface ArtifactsListProps {
-  artifacts: Artifact[];
+  artifacts: ArtifactFile[];
 }
 
 export const ArtifactsList: React.FC<ArtifactsListProps> = ({ artifacts }) => {
@@ -51,26 +45,22 @@ export const ArtifactsList: React.FC<ArtifactsListProps> = ({ artifacts }) => {
   const getFileTypeBadge = (type: string) => {
     const colors = {
       zip: 'bg-orange-100 text-orange-800',
-      md: 'bg-blue-100 text-blue-800', 
+      md: 'bg-blue-100 text-blue-800',
       txt: 'bg-gray-100 text-gray-800',
     };
-    
+
     return (
-      <Badge variant="secondary" className={colors[type as keyof typeof colors]}>
+      <Badge variant="secondary" className={colors[type as keyof typeof colors] ?? 'bg-gray-100 text-gray-800'}>
         {type.toUpperCase()}
       </Badge>
     );
   };
 
-  const handleDownload = (artifact: Artifact) => {
-    // Mock download - in real app would trigger actual download
-    console.log(`Downloading ${artifact.name}`);
+  const handleDownload = (artifact: ArtifactFile) => {
+    window.open(artifact.downloadUrl, '_blank', 'noopener');
   };
 
-  const getTotalSize = () => {
-    // Simple mock calculation - in real app would sum actual sizes
-    return '15.6 MB';
-  };
+  const totalSize = artifacts.reduce((acc, artifact) => acc + (artifact.size ?? 0), 0);
 
   return (
     <Card>
@@ -78,29 +68,29 @@ export const ArtifactsList: React.FC<ArtifactsListProps> = ({ artifacts }) => {
         <CardTitle className="flex items-center justify-between">
           <span>{t.title}</span>
           <Badge variant="outline">
-            {t.totalSize}: {getTotalSize()}
+            {t.totalSize}: {formatBytes(totalSize)}
           </Badge>
         </CardTitle>
       </CardHeader>
       <CardContent>
         <div className="space-y-3">
           {artifacts.map((artifact) => (
-            <div 
+            <div
               key={artifact.id}
               className="flex items-center justify-between p-4 border rounded-lg hover:bg-muted/50 transition-colors"
             >
               <div className="flex items-center gap-3">
-                {getFileIcon(artifact.type)}
+                {getFileIcon(artifact.kind)}
                 <div>
                   <h4 className="font-medium">{artifact.name}</h4>
                   <div className="flex items-center gap-2 mt-1">
-                    {getFileTypeBadge(artifact.type)}
-                    <span className="text-sm text-muted-foreground">{artifact.size}</span>
+                    {getFileTypeBadge(artifact.kind)}
+                    <span className="text-sm text-muted-foreground">{formatBytes(artifact.size)}</span>
                   </div>
                 </div>
               </div>
-              
-              <Button 
+
+              <Button
                 onClick={() => handleDownload(artifact)}
                 className="gap-2"
               >

--- a/figma/src/components/molecules/MaskEditor.tsx
+++ b/figma/src/components/molecules/MaskEditor.tsx
@@ -8,9 +8,13 @@ import { Label } from '../ui/label';
 import { Plus, X, Filter } from 'lucide-react';
 
 export const MaskEditor: React.FC = () => {
-  const { language } = useAppContext();
-  const [includeMasks, setIncludeMasks] = useState(['**/*.ts', '**/*.tsx', 'README.md']);
-  const [excludeMasks, setExcludeMasks] = useState(['node_modules/**', '.next/**', 'dist/**', 'coverage/**']);
+  const {
+    language,
+    includeMasks,
+    setIncludeMasks,
+    excludeMasks,
+    setExcludeMasks,
+  } = useAppContext();
   const [newInclude, setNewInclude] = useState('');
   const [newExclude, setNewExclude] = useState('');
 

--- a/figma/src/components/molecules/RefSelector.tsx
+++ b/figma/src/components/molecules/RefSelector.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useAppContext } from '../../App';
 import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
@@ -6,8 +6,12 @@ import { Badge } from '../ui/badge';
 import { GitBranch } from 'lucide-react';
 
 export const RefSelector: React.FC = () => {
-  const { language, repoData, setRepoData } = useAppContext();
+  const { language, repoData, setRepoData, setSelectedPaths, setTreeItems, setTreeSource } = useAppContext();
   const [selectedRef, setSelectedRef] = useState(repoData?.currentRef || 'main');
+
+  useEffect(() => {
+    setSelectedRef(repoData?.currentRef || 'main');
+  }, [repoData?.currentRef]);
 
   const texts = {
     ru: {
@@ -26,10 +30,17 @@ export const RefSelector: React.FC = () => {
 
   const handleRefChange = (newRef: string) => {
     setSelectedRef(newRef);
-    setRepoData({
-      ...repoData,
-      currentRef: newRef,
-    });
+    setRepoData((prev) =>
+      prev
+        ? {
+            ...prev,
+            currentRef: newRef,
+          }
+        : prev
+    );
+    setSelectedPaths([]);
+    setTreeItems([]);
+    setTreeSource(null);
   };
 
   return (

--- a/figma/src/components/organisms/TreeSelector.tsx
+++ b/figma/src/components/organisms/TreeSelector.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useAppContext } from '../../App';
 import { MaskEditor } from '../molecules/MaskEditor';
 import { FilePreview } from '../molecules/FilePreview';
@@ -9,6 +9,8 @@ import { Badge } from '../ui/badge';
 import { ScrollArea } from '../ui/scroll-area';
 import { Separator } from '../ui/separator';
 import { Search, Folder, File, FolderOpen, RefreshCw } from 'lucide-react';
+import { formatBytes } from '../../lib/utils';
+import { TreeItem } from '../../lib/types';
 
 interface TreeSelectorProps {
   selectedFiles: string[];
@@ -26,10 +28,10 @@ interface FileNode {
 }
 
 export const TreeSelector: React.FC<TreeSelectorProps> = ({ selectedFiles, onSelectionChange }) => {
-  const { language } = useAppContext();
+  const { language, treeItems, treeLoading, repoData, loadTree } = useAppContext();
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
-  const [expandedFolders, setExpandedFolders] = useState<Set<string>>(new Set(['src', 'components']));
+  const [expandedFolders, setExpandedFolders] = useState<Set<string>>(new Set());
 
   const texts = {
     ru: {
@@ -38,6 +40,8 @@ export const TreeSelector: React.FC<TreeSelectorProps> = ({ selectedFiles, onSel
       selectAll: 'Выбрать всё',
       noMatches: 'Нет совпадений по маскам',
       showingFirst: 'Показаны первые 1000 элементов, сузьте маски',
+      empty: 'Дерево пустое. Возможно, маски исключили все файлы.',
+      refresh: 'Обновить',
     },
     en: {
       searchPlaceholder: 'Search by path...',
@@ -45,73 +49,159 @@ export const TreeSelector: React.FC<TreeSelectorProps> = ({ selectedFiles, onSel
       selectAll: 'Select all',
       noMatches: 'No files match your masks',
       showingFirst: 'Showing first 1000 items, narrow down masks',
+      empty: 'Tree is empty. Your filters may exclude all files.',
+      refresh: 'Refresh',
     },
   };
 
   const t = texts[language];
 
-  // Mock file tree data
-  const mockFileTree: FileNode[] = [
-    {
-      name: 'src',
-      path: 'src',
-      type: 'folder',
-      children: [
-        {
-          name: 'components',
-          path: 'src/components',
-          type: 'folder',
-          children: [
-            { name: 'Button.tsx', path: 'src/components/Button.tsx', type: 'file', size: '2.1 KB' },
-            { name: 'Modal.tsx', path: 'src/components/Modal.tsx', type: 'file', size: '4.3 KB' },
-            { name: 'Form.tsx', path: 'src/components/Form.tsx', type: 'file', size: '8.2 KB' },
-          ],
-        },
-        {
-          name: 'utils',
-          path: 'src/utils',
-          type: 'folder',
-          children: [
-            { name: 'helpers.ts', path: 'src/utils/helpers.ts', type: 'file', size: '1.8 KB' },
-            { name: 'api.ts', path: 'src/utils/api.ts', type: 'file', size: '3.4 KB' },
-          ],
-        },
-        { name: 'index.tsx', path: 'src/index.tsx', type: 'file', size: '1.2 KB' },
-        { name: 'App.tsx', path: 'src/App.tsx', type: 'file', size: '5.7 KB' },
-      ],
-    },
-    {
-      name: 'public',
-      path: 'public',
-      type: 'folder',
-      children: [
-        { name: 'favicon.ico', path: 'public/favicon.ico', type: 'file', size: '15 KB' },
-        { name: 'logo.svg', path: 'public/logo.svg', type: 'file', size: '2.8 KB' },
-      ],
-    },
-    {
-      name: 'docs',
-      path: 'docs',
-      type: 'folder',
-      children: [
-        { name: 'README.md', path: 'docs/README.md', type: 'file', size: '12 KB' },
-        { name: 'CHANGELOG.md', path: 'docs/CHANGELOG.md', type: 'file', size: '8.5 KB' },
-      ],
-    },
-    { name: 'package.json', path: 'package.json', type: 'file', size: '2.3 KB' },
-    { name: 'tsconfig.json', path: 'tsconfig.json', type: 'file', size: '0.8 KB' },
-    { name: 'README.md', path: 'README.md', type: 'file', size: '4.2 KB' },
-    { name: 'large-dataset.csv', path: 'large-dataset.csv', type: 'file', size: '2.1 MB', isLFS: true },
-  ];
+  const tree = useMemo(() => {
+    if (!treeItems.length) {
+      return [] as FileNode[];
+    }
+
+    const dirMap = new Map<string, FileNode>();
+    const roots: FileNode[] = [];
+
+    const ensureDir = (path: string): FileNode => {
+      let node = dirMap.get(path);
+      if (!node) {
+        const parts = path.split('/');
+        const name = parts[parts.length - 1];
+        node = { name, path, type: 'folder', children: [] };
+        dirMap.set(path, node);
+        const parentPath = parts.slice(0, -1).join('/');
+        if (parentPath) {
+          const parent = ensureDir(parentPath);
+          parent.children = parent.children ?? [];
+          if (!parent.children.find(child => child.path === path)) {
+            parent.children.push(node);
+          }
+        } else if (!roots.find(child => child.path === path)) {
+          roots.push(node);
+        }
+      }
+      return node;
+    };
+
+    const addToParent = (node: FileNode, parentPath: string) => {
+      if (parentPath) {
+        const parent = ensureDir(parentPath);
+        parent.children = parent.children ?? [];
+        if (!parent.children.find(child => child.path === node.path)) {
+          parent.children.push(node);
+        }
+      } else if (!roots.find(child => child.path === node.path)) {
+        roots.push(node);
+      }
+    };
+
+    treeItems.forEach((item: TreeItem) => {
+      const parts = item.path.split('/');
+      const name = parts[parts.length - 1];
+      const parentPath = parts.slice(0, -1).join('/');
+
+      if (item.type === 'dir') {
+        const dir = ensureDir(item.path);
+        dir.name = name;
+        dir.isSubmodule = item.submodule;
+        addToParent(dir, parentPath);
+        return;
+      }
+
+      const fileNode: FileNode = {
+        name,
+        path: item.path,
+        type: 'file',
+        size: formatBytes(item.size),
+        isLFS: item.lfs,
+      };
+      addToParent(fileNode, parentPath);
+    });
+
+    const sortNodes = (nodes: FileNode[]) => {
+      nodes.sort((a, b) => {
+        if (a.type === b.type) {
+          return a.name.localeCompare(b.name);
+        }
+        return a.type === 'folder' ? -1 : 1;
+      });
+      nodes.forEach(node => {
+        if (node.children) {
+          sortNodes(node.children);
+        }
+      });
+    };
+
+    sortNodes(roots);
+    return roots;
+  }, [treeItems]);
+
+  useEffect(() => {
+    if (!treeItems.length) {
+      setExpandedFolders(new Set());
+      setSelectedFile(null);
+      return;
+    }
+
+    setExpandedFolders(prev => {
+      if (prev.size > 0) {
+        return prev;
+      }
+      const topLevel = new Set<string>();
+      treeItems.forEach(item => {
+        if (item.type === 'dir' && !item.path.includes('/')) {
+          topLevel.add(item.path);
+        }
+      });
+      return topLevel.size > 0 ? topLevel : prev;
+    });
+
+    if (!selectedFile) {
+      const firstFile = treeItems.find(item => item.type === 'file');
+      if (firstFile) {
+        setSelectedFile(firstFile.path);
+      }
+    }
+  }, [treeItems, selectedFile]);
+
+  const allFilePaths = useMemo(
+    () => treeItems.filter(item => item.type === 'file').map(item => item.path),
+    [treeItems]
+  );
+
+  const filteredTree = useMemo(() => {
+    if (!searchTerm.trim()) {
+      return tree;
+    }
+    const term = searchTerm.trim().toLowerCase();
+
+    const filterNodes = (nodes: FileNode[]): FileNode[] =>
+      nodes
+        .map(node => {
+          if (node.type === 'folder') {
+            const children = filterNodes(node.children ?? []);
+            if (node.path.toLowerCase().includes(term) || children.length > 0) {
+              return { ...node, children };
+            }
+            return null;
+          }
+          return node.path.toLowerCase().includes(term) ? node : null;
+        })
+        .filter((node): node is FileNode => node !== null);
+
+    return filterNodes(tree);
+  }, [tree, searchTerm]);
 
   const toggleFolder = (path: string) => {
-    const newExpanded = new Set(expandedFolders);
-    if (newExpanded.has(path)) {
-      newExpanded.delete(path);
+    const updated = new Set(expandedFolders);
+    if (updated.has(path)) {
+      updated.delete(path);
     } else {
-      newExpanded.add(path);
+      updated.add(path);
     }
-    setExpandedFolders(newExpanded);
+    setExpandedFolders(updated);
   };
 
   const toggleFileSelection = (path: string) => {
@@ -119,6 +209,19 @@ export const TreeSelector: React.FC<TreeSelectorProps> = ({ selectedFiles, onSel
       ? selectedFiles.filter(f => f !== path)
       : [...selectedFiles, path];
     onSelectionChange(newSelection);
+  };
+
+  const handleRefresh = () => {
+    if (!repoData) {
+      return;
+    }
+    loadTree(repoData.owner, repoData.repo, repoData.currentRef, true).catch(() => {
+      /* handled via treeError */
+    });
+  };
+
+  const handleSelectAll = () => {
+    onSelectionChange(allFilePaths);
   };
 
   const renderFileNode = (node: FileNode, level: number = 0): React.ReactNode => {
@@ -129,12 +232,12 @@ export const TreeSelector: React.FC<TreeSelectorProps> = ({ selectedFiles, onSel
     if (node.type === 'folder') {
       return (
         <div key={node.path}>
-          <div 
+          <div
             className="flex items-center gap-2 p-2 hover:bg-muted/50 cursor-pointer rounded-md"
             style={{ paddingLeft }}
             onClick={() => toggleFolder(node.path)}
           >
-            <Checkbox 
+            <Checkbox
               checked={isSelected}
               onCheckedChange={() => toggleFileSelection(node.path)}
               onClick={(e) => e.stopPropagation()}
@@ -145,6 +248,11 @@ export const TreeSelector: React.FC<TreeSelectorProps> = ({ selectedFiles, onSel
               <Folder className="w-4 h-4 text-blue-500" />
             )}
             <span className="font-medium">{node.name}</span>
+            {node.isSubmodule && (
+              <Badge variant="outline" className="text-xs">
+                Submodule
+              </Badge>
+            )}
           </div>
           {isExpanded && node.children && (
             <div>
@@ -156,7 +264,7 @@ export const TreeSelector: React.FC<TreeSelectorProps> = ({ selectedFiles, onSel
     }
 
     return (
-      <div 
+      <div
         key={node.path}
         className={`flex items-center justify-between gap-2 p-2 hover:bg-muted/50 cursor-pointer rounded-md ${
           selectedFile === node.path ? 'bg-primary/10' : ''
@@ -165,7 +273,7 @@ export const TreeSelector: React.FC<TreeSelectorProps> = ({ selectedFiles, onSel
         onClick={() => setSelectedFile(node.path)}
       >
         <div className="flex items-center gap-2 flex-1">
-          <Checkbox 
+          <Checkbox
             checked={isSelected}
             onCheckedChange={() => toggleFileSelection(node.path)}
             onClick={(e) => e.stopPropagation()}
@@ -173,10 +281,9 @@ export const TreeSelector: React.FC<TreeSelectorProps> = ({ selectedFiles, onSel
           <File className="w-4 h-4 text-muted-foreground" />
           <span>{node.name}</span>
           {node.isLFS && (
-            <Badge variant="secondary" className="text-xs">LFS</Badge>
-          )}
-          {node.isSubmodule && (
-            <Badge variant="outline" className="text-xs">Submodule</Badge>
+            <Badge variant="secondary" className="text-xs">
+              LFS
+            </Badge>
           )}
         </div>
         <span className="text-xs text-muted-foreground">{node.size}</span>
@@ -186,7 +293,6 @@ export const TreeSelector: React.FC<TreeSelectorProps> = ({ selectedFiles, onSel
 
   return (
     <div className="grid lg:grid-cols-2 gap-6">
-      {/* Left Panel - File Tree */}
       <div className="space-y-4">
         <div className="flex items-center gap-2">
           <div className="relative flex-1">
@@ -198,19 +304,31 @@ export const TreeSelector: React.FC<TreeSelectorProps> = ({ selectedFiles, onSel
               className="pl-10"
             />
           </div>
-          <Button variant="outline" size="sm" onClick={() => onSelectionChange([])}>
+          <Button variant="outline" size="sm" onClick={handleSelectAll} disabled={!allFilePaths.length}>
+            {t.selectAll}
+          </Button>
+          <Button variant="outline" size="sm" onClick={() => onSelectionChange([])} disabled={!selectedFiles.length}>
             {t.clearAll}
+          </Button>
+          <Button variant="outline" size="sm" onClick={handleRefresh} disabled={treeLoading}>
+            <RefreshCw className={`w-4 h-4 mr-2 ${treeLoading ? 'animate-spin' : ''}`} />
+            {t.refresh}
           </Button>
         </div>
 
         <ScrollArea className="h-96 border rounded-lg p-4">
           <div className="space-y-1">
-            {mockFileTree.map(node => renderFileNode(node))}
+            {filteredTree.length === 0 && !treeLoading ? (
+              <div className="text-sm text-muted-foreground py-8 text-center">
+                {searchTerm ? t.noMatches : t.empty}
+              </div>
+            ) : (
+              filteredTree.map(node => renderFileNode(node))
+            )}
           </div>
         </ScrollArea>
       </div>
 
-      {/* Right Panel - Masks and Preview */}
       <div className="space-y-6">
         <MaskEditor />
         <Separator />

--- a/figma/src/components/pages/Analyze.tsx
+++ b/figma/src/components/pages/Analyze.tsx
@@ -1,28 +1,132 @@
-import React from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useAppContext } from '../../App';
 import { RefSelector } from '../molecules/RefSelector';
 import { AnalyticsSummary } from '../molecules/AnalyticsSummary';
 import { WarningBanner } from '../molecules/WarningBanner';
 import { Button } from '../ui/button';
-import { ArrowRight, ArrowLeft } from 'lucide-react';
+import { ArrowRight, ArrowLeft, Loader2 } from 'lucide-react';
+import { TreeItem } from '../../lib/types';
+import { formatBytes } from '../../lib/utils';
 
 export const Analyze: React.FC = () => {
-  const { language, repoData, setCurrentPage } = useAppContext();
+  const {
+    language,
+    repoData,
+    setCurrentPage,
+    treeItems,
+    treeLoading,
+    treeError,
+    loadTree,
+  } = useAppContext();
 
   const texts = {
     ru: {
       title: 'Аналитика репозитория',
       backToRepo: 'Назад к репозиторию',
       toFileSelection: 'К выбору файлов',
+      loading: 'Загружаем дерево репозитория...',
+      failed: 'Не удалось загрузить дерево. Попробуйте обновить страницу.',
     },
     en: {
       title: 'Repository Analytics',
       backToRepo: 'Back to repository',
       toFileSelection: 'To file selection',
+      loading: 'Fetching repository tree...',
+      failed: 'Failed to load repository tree. Please try again.',
     },
   };
 
   const t = texts[language];
+
+  useEffect(() => {
+    if (repoData) {
+      loadTree(repoData.owner, repoData.repo, repoData.currentRef).catch(() => {
+        /* errors are surfaced via treeError */
+      });
+    }
+  }, [repoData?.owner, repoData?.repo, repoData?.currentRef, loadTree]);
+
+  const stats = useMemo(() => {
+    if (!treeItems.length) {
+      return null;
+    }
+    let totalSize = 0;
+    let fileCount = 0;
+    const languageSizes = new Map<string, number>();
+
+    const extensionToLanguage = (path: string) => {
+      const ext = path.split('.').pop()?.toLowerCase();
+      if (!ext) return 'Other';
+      const mapping: Record<string, string> = {
+        ts: 'TypeScript',
+        tsx: 'TypeScript',
+        js: 'JavaScript',
+        jsx: 'JavaScript',
+        py: 'Python',
+        go: 'Go',
+        rs: 'Rust',
+        java: 'Java',
+        kt: 'Kotlin',
+        cs: 'C#',
+        cpp: 'C++',
+        c: 'C',
+        rb: 'Ruby',
+        php: 'PHP',
+        swift: 'Swift',
+        m: 'Objective-C',
+        scala: 'Scala',
+        md: 'Markdown',
+        mdx: 'Markdown',
+        json: 'JSON',
+        yml: 'YAML',
+        yaml: 'YAML',
+        css: 'CSS',
+        scss: 'SCSS',
+        less: 'LESS',
+        html: 'HTML',
+        vue: 'Vue',
+        svelte: 'Svelte',
+      };
+      return mapping[ext] ?? ext.toUpperCase();
+    };
+
+    treeItems.forEach((item: TreeItem) => {
+      if (item.type === 'file') {
+        fileCount += 1;
+        totalSize += item.size;
+        const lang = extensionToLanguage(item.path);
+        languageSizes.set(lang, (languageSizes.get(lang) ?? 0) + item.size);
+      }
+    });
+
+    const languages = Array.from(languageSizes.entries())
+      .map(([name, size]) => ({ name, percentage: totalSize > 0 ? Math.round((size / totalSize) * 100) : 0 }))
+      .sort((a, b) => b.percentage - a.percentage);
+
+    if (!languages.length) {
+      languages.push({ name: 'Other', percentage: 100 });
+    }
+
+    return {
+      files: fileCount,
+      size: formatBytes(totalSize),
+      languages,
+    };
+  }, [treeItems]);
+
+  const warnings = useMemo(() => {
+    if (!treeItems.length) {
+      return [];
+    }
+    const result: string[] = [];
+    if (treeItems.some((item) => item.lfs)) {
+      result.push(language === 'ru' ? 'Обнаружены потенциальные файлы Git LFS или большие бинарные файлы.' : 'Potential Git LFS or large binary files detected.');
+    }
+    if (treeItems.some((item) => item.submodule)) {
+      result.push(language === 'ru' ? 'Репозиторий содержит git submodule.' : 'Repository contains git submodules.');
+    }
+    return result;
+  }, [treeItems, language]);
 
   if (!repoData) {
     return null;
@@ -35,10 +139,10 @@ export const Analyze: React.FC = () => {
           <div>
             <h1 className="text-3xl font-bold mb-2">{t.title}</h1>
             <p className="text-muted-foreground">
-              {repoData.owner}/{repoData.name}
+              {repoData.owner}/{repoData.repo}
             </p>
           </div>
-          
+
           <Button 
             variant="ghost" 
             onClick={() => setCurrentPage('landing')}
@@ -51,19 +155,36 @@ export const Analyze: React.FC = () => {
 
         <div className="space-y-6">
           <RefSelector />
-          
-          <AnalyticsSummary stats={repoData.stats} />
-          
-          {repoData.warnings?.length > 0 && (
-            <WarningBanner 
+
+          {treeLoading && (
+            <div className="flex items-center gap-2 text-muted-foreground">
+              <Loader2 className="w-4 h-4 animate-spin" />
+              <span>{t.loading}</span>
+            </div>
+          )}
+
+          {!treeLoading && treeError && (
+            <WarningBanner
+              type="error"
+              title={t.failed}
+              warnings={[treeError]}
+            />
+          )}
+
+          {!treeLoading && stats && (
+            <AnalyticsSummary stats={stats} />
+          )}
+
+          {!treeLoading && warnings.length > 0 && (
+            <WarningBanner
               type="warning"
-              title="Найдены предупреждения"
-              warnings={repoData.warnings}
+              title={language === 'ru' ? 'Найдены предупреждения' : 'Warnings detected'}
+              warnings={warnings}
             />
           )}
 
           <div className="flex justify-end pt-6">
-            <Button 
+            <Button
               onClick={() => setCurrentPage('select')}
               className="gap-2"
               size="lg"

--- a/figma/src/components/pages/Jobs.tsx
+++ b/figma/src/components/pages/Jobs.tsx
@@ -1,52 +1,137 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useAppContext } from '../../App';
 import { JobProgress } from '../molecules/JobProgress';
 import { Button } from '../ui/button';
 import { ArrowLeft } from 'lucide-react';
+import { ApiError, cancelJob, getJobStatus, getDownloadUrl, listArtifacts } from '../../lib/api';
 
 export const Jobs: React.FC = () => {
-  const { language, setCurrentPage } = useAppContext();
-  const [jobId] = useState('84213');
-  const [progress, setProgress] = useState(0);
-  const [currentStage, setCurrentStage] = useState(0);
+  const {
+    language,
+    setCurrentPage,
+    currentJob,
+    setCurrentJob,
+    setArtifacts,
+    setArtifactsExpiresAt,
+  } = useAppContext();
+  const [pollError, setPollError] = useState<string | null>(null);
+  const [isCanceling, setIsCanceling] = useState(false);
+  const [hasNavigated, setHasNavigated] = useState(false);
 
   const texts = {
     ru: {
       title: 'Задача',
       back: 'Назад',
+      noJob: 'Сначала создайте экспорт, чтобы отслеживать его прогресс.',
+      retry: 'Повторить запрос',
     },
     en: {
       title: 'Job',
       back: 'Back',
+      noJob: 'Create an export first to track its progress.',
+      retry: 'Retry',
     },
   };
 
   const t = texts[language];
 
-  // Simulate job progress
   useEffect(() => {
-    const interval = setInterval(() => {
-      setProgress(prev => {
-        const newProgress = prev + Math.random() * 10;
-        if (newProgress >= 100) {
-          clearInterval(interval);
-          setTimeout(() => setCurrentPage('result'), 1000);
-          return 100;
-        }
-        
-        // Update current stage based on progress
-        if (newProgress > 80) setCurrentStage(5);
-        else if (newProgress > 65) setCurrentStage(4);
-        else if (newProgress > 45) setCurrentStage(3);
-        else if (newProgress > 25) setCurrentStage(2);
-        else if (newProgress > 10) setCurrentStage(1);
-        
-        return newProgress;
-      });
-    }, 500);
+    setHasNavigated(false);
+    setPollError(null);
+  }, [currentJob?.id]);
 
-    return () => clearInterval(interval);
-  }, [setCurrentPage]);
+  useEffect(() => {
+    if (!currentJob) {
+      return;
+    }
+    let cancelled = false;
+
+    const poll = async () => {
+      try {
+        const status = await getJobStatus(currentJob.id);
+        if (cancelled) {
+          return;
+        }
+        setCurrentJob((prev) =>
+          prev
+            ? {
+                ...prev,
+                state: status.state,
+                progress: status.progress,
+                error: status.error ?? null,
+                exportId: status.exportId ?? prev.exportId,
+              }
+            : prev
+        );
+        setPollError(status.error ?? null);
+        if (status.state === 'done' && status.exportId && !hasNavigated) {
+          const artifactsResponse = await listArtifacts(status.exportId);
+          if (cancelled) {
+            return;
+          }
+          setArtifacts(
+            artifactsResponse.files.map((file) => ({
+              id: file.id,
+              kind: file.kind,
+              name: file.name,
+              size: file.size,
+              downloadUrl: getDownloadUrl(file.id),
+            }))
+          );
+          setArtifactsExpiresAt(artifactsResponse.expiresAt);
+          setHasNavigated(true);
+          setCurrentPage('result');
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setPollError(err instanceof ApiError ? err.message : language === 'ru' ? 'Ошибка обновления статуса.' : 'Failed to update job status.');
+        }
+      }
+    };
+
+    poll();
+    const interval = setInterval(poll, 2000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [currentJob?.id, hasNavigated, language, setArtifacts, setArtifactsExpiresAt, setCurrentJob, setCurrentPage]);
+
+  const handleCancel = () => {
+    if (!currentJob) {
+      return;
+    }
+    setIsCanceling(true);
+    cancelJob(currentJob.id).catch((err) => {
+      setPollError(err instanceof ApiError ? err.message : language === 'ru' ? 'Не удалось отменить задачу.' : 'Failed to cancel the job.');
+    }).finally(() => setIsCanceling(false));
+  };
+
+  const handleRetry = () => {
+    setPollError(null);
+  };
+
+  const jobState = useMemo(() => currentJob, [currentJob]);
+
+  if (!jobState) {
+    return (
+      <div className="min-h-screen bg-background">
+        <div className="container mx-auto px-4 py-8 max-w-4xl space-y-6">
+          <div className="flex items-center justify-between mb-4">
+            <h1 className="text-3xl font-bold">{t.title}</h1>
+            <Button variant="ghost" onClick={() => setCurrentPage('export')} className="gap-2">
+              <ArrowLeft className="w-4 h-4" />
+              {t.back}
+            </Button>
+          </div>
+          <p className="text-muted-foreground">{t.noJob}</p>
+          <Button onClick={() => setCurrentPage('export')} className="gap-2">
+            {language === 'ru' ? 'К настройкам экспорта' : 'Go to export settings'}
+          </Button>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-background">
@@ -54,11 +139,11 @@ export const Jobs: React.FC = () => {
         <div className="flex items-center justify-between mb-8">
           <div>
             <h1 className="text-3xl font-bold">
-              {t.title} #{jobId}
+              {t.title} #{jobState.id}
             </h1>
           </div>
-          <Button 
-            variant="ghost" 
+          <Button
+            variant="ghost"
             onClick={() => setCurrentPage('export')}
             className="gap-2"
           >
@@ -67,11 +152,22 @@ export const Jobs: React.FC = () => {
           </Button>
         </div>
 
-        <JobProgress 
-          progress={progress}
-          currentStage={currentStage}
-          jobId={jobId}
+        <JobProgress
+          progress={jobState.progress}
+          jobId={jobState.id}
+          state={jobState.state}
+          error={pollError ?? jobState.error ?? null}
+          onCancel={handleCancel}
+          cancelDisabled={isCanceling}
         />
+
+        {pollError && (
+          <div className="mt-6 flex justify-end">
+            <Button size="sm" variant="outline" onClick={handleRetry}>
+              {t.retry}
+            </Button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/figma/src/lib/api.ts
+++ b/figma/src/lib/api.ts
@@ -1,0 +1,106 @@
+import {
+  ApiErrorPayload,
+  ArtifactsResponse,
+  ExportRequest,
+  ExportResponse,
+  JobStatusResponse,
+  PreviewRequest,
+  PreviewResponse,
+  ResolveResponse,
+  TreeResponse,
+} from './types';
+
+export class ApiError extends Error {
+  status: number;
+  code?: string;
+  details?: Record<string, unknown>;
+
+  constructor(status: number, message: string, code?: string, details?: Record<string, unknown>) {
+    super(message);
+    this.status = status;
+    this.code = code;
+    this.details = details;
+  }
+}
+
+const API_BASE = (import.meta.env.VITE_API_BASE_URL ?? '').replace(/\/$/, '');
+
+const buildUrl = (path: string) => {
+  if (!path.startsWith('/')) {
+    throw new Error(`API paths must start with '/': received ${path}`);
+  }
+  if (!API_BASE) {
+    return path;
+  }
+  return `${API_BASE}${path}`;
+};
+
+const handleError = async (response: Response): Promise<never> => {
+  let message = `Request failed with status ${response.status}`;
+  let code: string | undefined;
+  let details: Record<string, unknown> | undefined;
+  try {
+    const payload = (await response.json()) as ApiErrorPayload;
+    if (payload?.error?.message) {
+      message = payload.error.message;
+    }
+    if (payload?.error?.code) {
+      code = payload.error.code;
+    }
+    if (payload?.error?.details) {
+      details = payload.error.details;
+    }
+  } catch {
+    // ignore json parsing errors
+  }
+  throw new ApiError(response.status, message, code, details);
+};
+
+const request = async <T>(path: string, init?: RequestInit): Promise<T> => {
+  const res = await fetch(buildUrl(path), {
+    headers: {
+      'Content-Type': 'application/json',
+      ...(init?.headers ?? {}),
+    },
+    ...init,
+  });
+  if (!res.ok) {
+    await handleError(res);
+  }
+  if (res.status === 204) {
+    return undefined as T;
+  }
+  return (await res.json()) as T;
+};
+
+export const resolveRepository = (url: string): Promise<ResolveResponse> =>
+  request<ResolveResponse>('/api/repo/resolve', {
+    method: 'POST',
+    body: JSON.stringify({ url }),
+  });
+
+export const fetchRepositoryTree = (owner: string, repo: string, ref: string): Promise<TreeResponse> =>
+  request<TreeResponse>(`/api/repo/tree?owner=${encodeURIComponent(owner)}&repo=${encodeURIComponent(repo)}&ref=${encodeURIComponent(ref)}`);
+
+export const fetchFilePreview = ({ owner, repo, ref, path, maxKB = 256 }: PreviewRequest): Promise<PreviewResponse> =>
+  request<PreviewResponse>('/api/preview', {
+    method: 'POST',
+    body: JSON.stringify({ owner, repo, ref, path, maxKB }),
+  });
+
+export const createExport = (payload: ExportRequest): Promise<ExportResponse> =>
+  request<ExportResponse>('/api/export', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+
+export const getJobStatus = (jobId: string): Promise<JobStatusResponse> =>
+  request<JobStatusResponse>(`/api/jobs/${encodeURIComponent(jobId)}`);
+
+export const cancelJob = (jobId: string): Promise<void> =>
+  request<void>(`/api/jobs/${encodeURIComponent(jobId)}/cancel`, { method: 'POST' });
+
+export const listArtifacts = (exportId: string): Promise<ArtifactsResponse> =>
+  request<ArtifactsResponse>(`/api/artifacts/${encodeURIComponent(exportId)}`);
+
+export const getDownloadUrl = (artifactId: string): string => buildUrl(`/api/download/${encodeURIComponent(artifactId)}`);

--- a/figma/src/lib/types.ts
+++ b/figma/src/lib/types.ts
@@ -1,0 +1,109 @@
+export type Theme = 'light' | 'dark';
+export type Page = 'landing' | 'analyze' | 'select' | 'export' | 'jobs' | 'result';
+
+export interface RepoData {
+  url: string;
+  owner: string;
+  repo: string;
+  defaultRef: string;
+  currentRef: string;
+  refs: string[];
+  stats?: RepoStats;
+  warnings?: string[];
+}
+
+export interface RepoStats {
+  files: number;
+  sizeBytes: number;
+  languages: Array<{ name: string; percentage: number }>;
+}
+
+export interface ResolveResponse {
+  Owner: string;
+  Repo: string;
+  DefaultRef: string;
+  Refs: string[];
+}
+
+export interface TreeItem {
+  path: string;
+  type: 'file' | 'dir';
+  size: number;
+  lfs: boolean;
+  submodule: boolean;
+}
+
+export interface TreeResponse {
+  items: TreeItem[];
+}
+
+export interface PreviewRequest {
+  owner: string;
+  repo: string;
+  ref: string;
+  path: string;
+  maxKB?: number;
+}
+
+export interface PreviewResponse {
+  content: string;
+  truncated: boolean;
+}
+
+export interface ExportRequest {
+  owner: string;
+  repo: string;
+  ref: string;
+  format: 'zip' | 'md' | 'txt';
+  profile: string;
+  includeGlobs: string[];
+  excludeGlobs: string[];
+  secretScan: boolean;
+  secretStrategy: string;
+  tokenModel: string;
+  maxBinarySizeMB: number;
+  ttlHours: number;
+}
+
+export interface ExportResponse {
+  jobId: string;
+}
+
+export type JobStatus = 'queued' | 'running' | 'done' | 'error' | 'timeout' | 'canceled';
+
+export interface JobStatusResponse {
+  state: JobStatus;
+  progress: number;
+  error?: string | null;
+  exportId?: string;
+  artifacts?: Array<{ id: string; kind: string; size: number }>;
+}
+
+export interface JobState {
+  id: string;
+  state: JobStatus;
+  progress: number;
+  error?: string | null;
+  exportId?: string;
+}
+
+export interface ArtifactFile {
+  id: string;
+  kind: string;
+  name: string;
+  size: number;
+  downloadUrl: string;
+}
+
+export interface ArtifactsResponse {
+  files: Array<{ id: string; kind: string; name: string; size: number }>;
+  expiresAt: string;
+}
+
+export interface ApiErrorPayload {
+  error: {
+    code: string;
+    message: string;
+    details?: Record<string, unknown>;
+  };
+}

--- a/figma/src/lib/utils.ts
+++ b/figma/src/lib/utils.ts
@@ -1,0 +1,9 @@
+export const formatBytes = (bytes: number): string => {
+  if (!Number.isFinite(bytes) || bytes <= 0) {
+    return '0 B';
+  }
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  const value = bytes / Math.pow(1024, exponent);
+  return `${value.toFixed(value >= 10 || exponent === 0 ? 0 : 1)} ${units[exponent]}`;
+};

--- a/figma/vite.config.ts
+++ b/figma/vite.config.ts
@@ -1,13 +1,17 @@
 
-  import { defineConfig } from 'vite';
+  import { defineConfig, loadEnv } from 'vite';
   import react from '@vitejs/plugin-react-swc';
   import path from 'path';
 
-  export default defineConfig({
-    plugins: [react()],
-    resolve: {
-      extensions: ['.js', '.jsx', '.ts', '.tsx', '.json'],
-      alias: {
+  export default defineConfig(({ mode }) => {
+    const env = loadEnv(mode, process.cwd(), '');
+    const proxyTarget = env.VITE_DEV_API_PROXY ?? env.API_PROXY_TARGET ?? 'http://localhost:8080';
+
+    return {
+      plugins: [react()],
+      resolve: {
+        extensions: ['.js', '.jsx', '.ts', '.tsx', '.json'],
+        alias: {
         'vaul@1.1.2': 'vaul',
         'sonner@2.0.3': 'sonner',
         'recharts@2.15.2': 'recharts',
@@ -46,15 +50,23 @@
         '@radix-ui/react-aspect-ratio@1.1.2': '@radix-ui/react-aspect-ratio',
         '@radix-ui/react-alert-dialog@1.1.6': '@radix-ui/react-alert-dialog',
         '@radix-ui/react-accordion@1.2.3': '@radix-ui/react-accordion',
-        '@': path.resolve(__dirname, './src'),
+          '@': path.resolve(__dirname, './src'),
+        },
       },
-    },
-    build: {
-      target: 'esnext',
-      outDir: 'build',
-    },
-    server: {
-      port: 3000,
-      open: true,
-    },
+      build: {
+        target: 'esnext',
+        outDir: 'build',
+      },
+      server: {
+        port: 3000,
+        open: true,
+        proxy: {
+          '/api': {
+            target: proxyTarget,
+            changeOrigin: true,
+            secure: false,
+          },
+        },
+      },
+    };
   });


### PR DESCRIPTION
## Summary
- configure the Vite dev server to proxy `/api` traffic to the Go backend and allow overriding the target via environment variables
- document the backend startup, proxy behaviour, and production `VITE_API_BASE_URL` usage in the frontend README

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d05c76b094832cbaf8ed21761a4ff8