### PR TITLE
Fix clearing export error message

### DIFF
--- a/backend/internal/store/exports_mem.go
+++ b/backend/internal/store/exports_mem.go
@@ -126,9 +126,8 @@ func (s *ExportsMem) UpdateStatus(id string, st jobs.Status, progress int, errTe
 		if progress >= 0 {
 			e.Progress = progress
 		}
-		if errText != nil {
-			e.ErrorText = errText
-		}
+		// обновляем текст ошибки: если передали nil — очищаем прошлое сообщение
+		e.ErrorText = errText
 		now := time.Now().UTC()
 		switch st {
 		case jobs.StatusRunning:


### PR DESCRIPTION
## Summary
- reset stored export error message whenever status changes to avoid stale errors after retries
- document behavior via inline comment in the in-memory export store

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d17a8a6ccc832ca1bf6dd187d6eb35