### PR TITLE
Fix artifact metadata, prompt profile normalization, and secret scanning toggle

### DIFF
--- a/backend/internal/artifacts/store_fs.go
+++ b/backend/internal/artifacts/store_fs.go
@@ -39,9 +39,9 @@ type Manifest struct {
 }
 
 type FSStore struct {
-	root     string       // корень, например ./data/artifacts
-	ttlHours int          // дефолтный TTL для новых manifest
-	mu       sync.Mutex   // защищает запись manifest
+	root     string     // корень, например ./data/artifacts
+	ttlHours int        // дефолтный TTL для новых manifest
+	mu       sync.Mutex // защищает запись manifest
 	reSafeID *regexp.Regexp
 }
 
@@ -79,6 +79,13 @@ func (aw *ArtifactWriter) Close() error {
 	}
 	aw.meta.Size = fi.Size()
 	return aw.store.updateManifest(aw.exportID, aw.meta)
+}
+
+// Meta возвращает актуальные метаданные артефакта.
+// Дополнительно Close() обновляет размер, поэтому вызывать Meta имеет смысл
+// после успешного закрытия writer.
+func (aw *ArtifactWriter) Meta() ArtifactMeta {
+	return aw.meta
 }
 
 // CreateArtifact создаёт файл <root>/<exportId>/<name> и вернёт writer + метаданные.

--- a/backend/internal/exporter/txtbuilder.go
+++ b/backend/internal/exporter/txtbuilder.go
@@ -1,8 +1,8 @@
 package exporter
 
 import (
-	"archive/tar"   // читаем TAR
-	"bufio"         // построчное чтение
+	"archive/tar" // читаем TAR
+	"bufio"       // построчное чтение
 	"bytes"
 	"compress/gzip" // распаковываем .tar.gz
 	"fmt"
@@ -16,16 +16,16 @@ import (
 
 // TxtOptions — параметры экспорта TXT.
 type TxtOptions struct {
-	IncludeGlobs    []string          // маски include
-	ExcludeGlobs    []string          // маски exclude
-	StripFirstDir   bool              // срезать первый сегмент (у GitHub tar это repo-<sha>/...)
-	LineNumbers     bool              // печатать "N\tстрока"
-	HeaderTemplate  string            // заголовок перед каждым файлом: поддерживает {path} и {n}
-	MaxLinesPerFile int               // 0 = без обрезки; иначе ограничиваем строки на файл
-	MaxExportMB     int               // общий лимит выходного TXT (в мегабайтах); 0 = без лимита
-	SkipBinaries    bool              // пропускать «бинарные» файлы (эвристика)
-	SecretScan      bool              // включить сканирование (дефолт: true)
-	SecretStrategy  secrets.Strategy  // стратегия (дефолт: REDACTED)
+	IncludeGlobs    []string         // маски include
+	ExcludeGlobs    []string         // маски exclude
+	StripFirstDir   bool             // срезать первый сегмент (у GitHub tar это repo-<sha>/...)
+	LineNumbers     bool             // печатать "N\tстрока"
+	HeaderTemplate  string           // заголовок перед каждым файлом: поддерживает {path} и {n}
+	MaxLinesPerFile int              // 0 = без обрезки; иначе ограничиваем строки на файл
+	MaxExportMB     int              // общий лимит выходного TXT (в мегабайтах); 0 = без лимита
+	SkipBinaries    bool             // пропускать «бинарные» файлы (эвристика)
+	SecretScan      bool             // включить сканирование (дефолт: true)
+	SecretStrategy  secrets.Strategy // стратегия (дефолт: REDACTED)
 }
 
 // BuildTxtFromTarGz — конвертит tar.gz поток в «плоский» TXT.
@@ -39,13 +39,8 @@ func BuildTxtFromTarGz(src io.Reader, dst io.Writer, opts TxtOptions) error {
 	if opts.MaxLinesPerFile < 0 {
 		opts.MaxLinesPerFile = 0
 	}
-	// по умолчанию — включаем сканирование с REDACTED
-	doScan := true
-	if opts.SecretScan { // пользователь мог явно включить
-		doScan = true
-	} else if !opts.SecretScan { // бул по умолчанию = false → включим вручную
-		doScan = true
-	}
+	// Управление сканированием секретов: если опция включена — создаём сканер.
+	doScan := opts.SecretScan
 	strategy := opts.SecretStrategy
 	if strategy != secrets.StrategyRedacted &&
 		strategy != secrets.StrategyStrip &&


### PR DESCRIPTION
## Summary
- ensure artifact writers expose updated metadata and the worker closes files before recording job results
- normalize prompt pack profile selection so the RAG profile uses the correct settings
- respect the SecretScan option in the TXT exporter to allow disabling secret masking

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d1a9a32b30832c8ef29befee8ee2f8