### PR TITLE
Fix export errors localization and translate job stages

### DIFF
--- a/figma/src/components/molecules/ExportForm.tsx
+++ b/figma/src/components/molecules/ExportForm.tsx
@@ -51,6 +51,10 @@ export const ExportForm: React.FC = () => {
       maxBinaryLabel: 'Макс. размер бинарных файлов (МБ)',
       createExport: 'Создать экспорт',
       advanced: 'Дополнительные настройки',
+      errors: {
+        noRepo: 'Сначала выберите репозиторий.',
+        generic: 'Не удалось создать экспорт.',
+      },
     },
     en: {
       title: 'Export Parameters',
@@ -69,12 +73,12 @@ export const ExportForm: React.FC = () => {
       maxBinaryLabel: 'Max Binary File Size (MB)',
       createExport: 'Create Export',
       advanced: 'Advanced Settings',
-      errorNoRepo: 'Сначала выберите репозиторий.',
-      errorGeneric: 'Не удалось создать экспорт.',
-      errorNoRepoEn: 'Please resolve a repository first.',
-      errorGenericEn: 'Failed to create export.',
+      errors: {
+        noRepo: 'Please resolve a repository first.',
+        generic: 'Failed to create export.',
+      },
     },
-  };
+  } as const;
 
   const t = texts[language];
 
@@ -91,7 +95,7 @@ export const ExportForm: React.FC = () => {
 
   const handleSubmit = () => {
     if (!repoData) {
-      setError(language === 'ru' ? texts.ru.errorNoRepo : texts.en.errorNoRepoEn);
+      setError(t.errors.noRepo);
       return;
     }
     setSubmitting(true);
@@ -117,11 +121,11 @@ export const ExportForm: React.FC = () => {
         setCurrentPage('jobs');
       })
       .catch((err) => {
-        if (err instanceof ApiError) {
+        if (err instanceof ApiError && err.message) {
           setError(err.message);
-        } else {
-          setError(language === 'ru' ? texts.ru.errorGeneric : texts.en.errorGenericEn);
+          return;
         }
+        setError(t.errors.generic);
       })
       .finally(() => setSubmitting(false));
   };

--- a/figma/src/components/molecules/JobProgress.tsx
+++ b/figma/src/components/molecules/JobProgress.tsx
@@ -58,6 +58,7 @@ export const JobProgress: React.FC<JobProgressProps> = ({ progress, jobId, state
       statusTimeout: 'Таймаут',
       job: 'Задача',
       canceledNotice: 'Задача была отменена.',
+      stagesTitle: 'Этапы выполнения',
     },
     en: {
       progress: 'Progress',
@@ -86,6 +87,7 @@ export const JobProgress: React.FC<JobProgressProps> = ({ progress, jobId, state
       statusTimeout: 'Timed out',
       job: 'Job',
       canceledNotice: 'The job was canceled.',
+      stagesTitle: 'Execution stages',
     },
   };
 
@@ -202,7 +204,7 @@ export const JobProgress: React.FC<JobProgressProps> = ({ progress, jobId, state
       {/* Stage List */}
       <Card>
         <CardHeader>
-          <CardTitle>Этапы выполнения</CardTitle>
+          <CardTitle>{t.stagesTitle}</CardTitle>
         </CardHeader>
         <CardContent>
           <div className="space-y-4">


### PR DESCRIPTION
## Summary
- ensure export form shows localized validation and fallback errors in both languages
- localize the job progress stage list title to respect the selected language

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d28bd502e8832cbded2823e075ea3d