### PR TITLE
Limit export to selected files

### DIFF
--- a/figma/src/components/molecules/ExportForm.tsx
+++ b/figma/src/components/molecules/ExportForm.tsx
@@ -17,6 +17,7 @@ export const ExportForm: React.FC = () => {
     language,
     setCurrentPage,
     repoData,
+    selectedPaths,
     includeMasks,
     excludeMasks,
     filtersEnabled,
@@ -100,14 +101,25 @@ export const ExportForm: React.FC = () => {
     }
     setSubmitting(true);
     setError(null);
+    const includeGlobs = (() => {
+      if (selectedPaths.length > 0) {
+        return selectedPaths;
+      }
+      if (filtersEnabled) {
+        return includeMasks;
+      }
+      return [];
+    })();
+    const excludeGlobs = filtersEnabled ? excludeMasks : [];
+
     createExport({
       owner: repoData.owner,
       repo: repoData.repo,
       ref: repoData.currentRef,
       format: format as 'zip' | 'md' | 'txt',
       profile,
-      includeGlobs: filtersEnabled ? includeMasks : [],
-      excludeGlobs: filtersEnabled ? excludeMasks : [],
+      includeGlobs,
+      excludeGlobs,
       secretScan,
       secretStrategy: 'mask',
       tokenModel: tokenModelId,


### PR DESCRIPTION
## Summary
- send the selected files from the tree selector as the include glob list when creating an export request
- fall back to mask-based filtering only when nothing is selected so exports default to the full repository

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2ce804218832c9be00f8da34dd191