### PR TITLE
Add structured logging, SSE job updates, and export tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ figma/.eslintcache
 figma/npm-debug.log*
 figma/yarn-error.log*
 figma/pnpm-debug.log*
+figma/build/
 
 # --- Ненужные системные файлы в подкаталогах ---
 **/.DS_Store

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -1,26 +1,29 @@
 package main
 
 import (
-	"log"
+	"log/slog"
 	"net/http"
+	"os"
 
 	"github.com/yourname/cleanhttp/internal/config"
 	"github.com/yourname/cleanhttp/internal/httpserver"
 )
 
-func main(){
+func main() {
 	cfg, err := config.Load()
 	if err != nil {
-		log.Fatalf("config error: %v", err)
-	}	
+		slog.Error("config error", slog.String("error", err.Error()))
+		os.Exit(1)
+	}
 
 	addr := ":" + cfg.Port
 	h := httpserver.New(cfg)
-	log.Printf("starting http server on %s (env=%s, timeout=%s)", addr, cfg.Env, cfg.RequestTimeout)
+	slog.Info("starting http server", slog.String("addr", addr), slog.String("env", string(cfg.Env)), slog.Duration("timeout", cfg.RequestTimeout))
 	// Стартуем блокирующе. Если сервер завершился с ошибкой — фатал.
 	// (Позже заменим на http.Server + Shutdown(ctx) для graceful).
 	if err := http.ListenAndServe(addr, h); err != nil {
-		log.Fatalf("server stopped: %v", err)
+		slog.Error("server stopped", slog.String("error", err.Error()))
+		os.Exit(1)
 	}
 
 }

--- a/backend/internal/exporter/txtbuilder_test.go
+++ b/backend/internal/exporter/txtbuilder_test.go
@@ -1,0 +1,44 @@
+package exporter
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestBuildTxt_TruncateAndStrip(t *testing.T) {
+	src := makeTarGz(map[string]string{
+		"path/to/file.txt": "line1\nline2\nline3\nline4\n",
+	})
+	var out bytes.Buffer
+	opts := TxtOptions{
+		IncludeGlobs:    []string{"**/*.txt"},
+		StripFirstDir:   true,
+		MaxLinesPerFile: 2,
+		LineNumbers:     false,
+	}
+	if err := BuildTxtFromTarGz(bytes.NewReader(src), &out, opts); err != nil {
+		t.Fatalf("build txt: %v", err)
+	}
+	result := out.String()
+	if !strings.Contains(result, "=== FILE: path/to/file.txt (first 2 lines) ===") {
+		t.Fatalf("header missing: %s", result)
+	}
+	if !strings.Contains(result, "… (truncated)") {
+		t.Fatalf("expected truncated marker, got: %s", result)
+	}
+}
+
+func TestBuildTxt_TooLargeLimit(t *testing.T) {
+	big := strings.Repeat("a\n", 600000) // ~1.2MB
+	src := makeTarGz(map[string]string{"large.txt": big})
+	var out bytes.Buffer
+	opts := TxtOptions{StripFirstDir: true, MaxExportMB: 1}
+	err := BuildTxtFromTarGz(bytes.NewReader(src), &out, opts)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if err != ErrExportTooLarge {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/backend/internal/exporter/zipbuilder_test.go
+++ b/backend/internal/exporter/zipbuilder_test.go
@@ -2,9 +2,10 @@ package exporter
 
 import (
 	"archive/tar"
+	"archive/zip"
 	"bytes"
 	"compress/gzip"
-	_"io"
+	"sort"
 	"testing"
 )
 
@@ -20,25 +21,67 @@ func makeTarGz(files map[string]string) []byte {
 		})
 		_, _ = tw.Write(b)
 	}
-	_ = tw.Close(); _ = gz.Close()
+	_ = tw.Close()
+	_ = gz.Close()
 	return buf.Bytes()
 }
 
-func Test_ZipBuilder_FiltersAndLimit(t *testing.T) {
+func TestBuildZip_IncludeExcludeAndStrip(t *testing.T) {
 	src := makeTarGz(map[string]string{
-		"a/b.go": "package x\n", "a/b_test.go": "package x\n", "node_modules/x.js":"var x=1;",
+		"src/keep.txt":       "hello",
+		"src/skip.log":       "nope",
+		"docs/readme.md":     "doc",
+		"node_modules/x.js":  "var x=1;",
+		"nested/inner/test":  "data",
+		"nested/inner/test2": "data",
 	})
 	var out bytes.Buffer
-	err := BuildZipFromTarGz(bytes.NewReader(src), &out, Options{
-		IncludeGlobs: []string{"**/*.go"},
-		ExcludeGlobs: []string{"**/*_test.go","node_modules/**"},
+	opts := Options{
+		IncludeGlobs:  []string{"**/*.txt", "docs/**"},
+		ExcludeGlobs:  []string{"**/*.log", "nested/**"},
 		StripFirstDir: true,
-		MaxExportMB: 1,
-	})
+		MaxExportMB:   10,
+	}
+	if err := BuildZipFromTarGz(bytes.NewReader(src), &out, opts); err != nil {
+		t.Fatalf("build zip: %v", err)
+	}
+	names := zipEntries(t, out.Bytes())
+	want := []string{"docs/readme.md", "src/keep.txt"}
+	sort.Strings(names)
+	sort.Strings(want)
+	if len(names) != len(want) {
+		t.Fatalf("unexpected entries: got %v", names)
+	}
+	for i, w := range want {
+		if names[i] != w {
+			t.Fatalf("entry %d mismatch: want %q got %q", i, w, names[i])
+		}
+	}
+}
+
+func TestBuildZip_TooLargeLimit(t *testing.T) {
+	big := bytes.Repeat([]byte("a"), 2*1024*1024)
+	src := makeTarGz(map[string]string{"big.bin": string(big)})
+	var out bytes.Buffer
+	err := BuildZipFromTarGz(bytes.NewReader(src), &out, Options{StripFirstDir: true, MaxExportMB: 1})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if err != ErrExportTooLarge {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func zipEntries(t *testing.T, data []byte) []string {
+	t.Helper()
+	rdr := bytes.NewReader(data)
+	zr, err := zip.NewReader(rdr, int64(len(data)))
 	if err != nil {
-		t.Fatalf("zip build: %v", err)
+		t.Fatalf("open zip: %v", err)
 	}
-	if out.Len() == 0 {
-		t.Fatal("empty zip")
+	names := make([]string, 0, len(zr.File))
+	for _, f := range zr.File {
+		names = append(names, f.Name)
 	}
+	return names
 }

--- a/backend/internal/handlers/jobs.go
+++ b/backend/internal/handlers/jobs.go
@@ -1,11 +1,13 @@
 package handlers
 
 import (
+	"encoding/json"
+	"log/slog"
 	"net/http"
 	"strings"
 
 	"github.com/yourname/cleanhttp/internal/httputil"
-	_"github.com/yourname/cleanhttp/internal/jobs"
+	"github.com/yourname/cleanhttp/internal/jobs"
 	"github.com/yourname/cleanhttp/internal/store"
 )
 
@@ -25,20 +27,8 @@ func (h *JobStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if exp, ok := h.Exports.Get(id); ok {
-		type resp struct {
-			State     string                 `json:"state"`
-			Progress  int                    `json:"progress"`
-			Error     *string                `json:"error"`
-			ExportID  string                 `json:"exportId"`
-			Artifacts []store.ArtifactMeta   `json:"artifacts"`
-		}
-		httputil.WriteJSON(w, http.StatusOK, resp{
-			State:     string(exp.Status),
-			Progress:  exp.Progress,
-			Error:     exp.ErrorText,
-			ExportID:  exp.ID,
-			Artifacts: exp.Artifacts,
-		})
+		resp := jobStatusResponse(exp)
+		httputil.WriteJSON(w, http.StatusOK, resp)
 		return
 	}
 	httputil.WriteError(w, http.StatusNotFound, "not_found", "job not found", nil)
@@ -60,10 +50,135 @@ func (h *JobCancelHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		httputil.WriteError(w, http.StatusBadRequest, "bad_request", "missing id", nil)
 		return
 	}
-	ok := h.Exports.RequestCancel(id)
-	if !ok {
+	if !h.Exports.RequestCancel(id) {
 		httputil.WriteError(w, http.StatusConflict, "conflict", "job already finished or not found", nil)
 		return
 	}
 	httputil.WriteJSON(w, http.StatusOK, map[string]any{"ok": true})
+}
+
+// JobEventsHandler — SSE стрим обновлений статуса.
+type JobEventsHandler struct {
+	Exports *store.ExportsMem
+	Logger  *slog.Logger
+}
+
+func (h *JobEventsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		httputil.WriteError(w, http.StatusMethodNotAllowed, "method_not_allowed", "only GET", nil)
+		return
+	}
+	if r.Header.Get("Accept") != "text/event-stream" {
+		// Не обязательно, но помогает дебагу.
+	}
+	id := strings.TrimPrefix(r.URL.Path, "/jobs/")
+	id = strings.TrimSuffix(id, "/events")
+	if id == "" {
+		httputil.WriteError(w, http.StatusBadRequest, "bad_request", "missing id", nil)
+		return
+	}
+	exp, ok := h.Exports.Get(id)
+	if !ok {
+		httputil.WriteError(w, http.StatusNotFound, "not_found", "job not found", nil)
+		return
+	}
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		httputil.WriteError(w, http.StatusInternalServerError, "stream_not_supported", "streaming not supported", nil)
+		return
+	}
+
+	ctx := r.Context()
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	// Отправляем стартовое состояние
+	if err := writeSSE(w, flusher, exp); err != nil {
+		if h.Logger != nil {
+			h.Logger.Error("sse initial send failed", slog.String("exportId", id), slog.String("error", err.Error()))
+		}
+		return
+	}
+
+	ch, unsubscribe, ok := h.Exports.Subscribe(id)
+	if !ok {
+		httputil.WriteError(w, http.StatusNotFound, "not_found", "job not found", nil)
+		return
+	}
+	defer unsubscribe()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case snap, more := <-ch:
+			if !more {
+				return
+			}
+			if err := writeSSE(w, flusher, snap); err != nil {
+				if h.Logger != nil {
+					h.Logger.Error("sse send failed", slog.String("exportId", id), slog.String("error", err.Error()))
+				}
+				return
+			}
+			if isTerminalState(snap.Status) {
+				return
+			}
+		}
+	}
+}
+
+func writeSSE(w http.ResponseWriter, flusher http.Flusher, data any) error {
+	payload := jobStatusResponseFromSnapshot(data)
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write([]byte("data: ")); err != nil {
+		return err
+	}
+	if _, err := w.Write(b); err != nil {
+		return err
+	}
+	if _, err := w.Write([]byte("\n\n")); err != nil {
+		return err
+	}
+	flusher.Flush()
+	return nil
+}
+
+func jobStatusResponse(exp *store.Export) map[string]any {
+	return map[string]any{
+		"state":           string(exp.Status),
+		"progress":        exp.Progress,
+		"failureReason":   exp.FailureReason,
+		"error":           exp.FailureReason,
+		"cancelRequested": exp.CancelRequested,
+		"exportId":        exp.ID,
+		"artifacts":       exp.Artifacts,
+	}
+}
+
+func jobStatusResponseFromSnapshot(v any) map[string]any {
+	switch data := v.(type) {
+	case *store.Export:
+		return jobStatusResponse(data)
+	case store.ExportSnapshot:
+		return map[string]any{
+			"state":           string(data.Status),
+			"progress":        data.Progress,
+			"failureReason":   data.FailureReason,
+			"error":           data.FailureReason,
+			"cancelRequested": data.CancelRequested,
+			"exportId":        data.ID,
+			"artifacts":       data.Artifacts,
+		}
+	default:
+		return map[string]any{}
+	}
+}
+
+func isTerminalState(st jobs.Status) bool {
+	return st == jobs.StatusDone || st == jobs.StatusError || st == jobs.StatusCancelled
 }

--- a/backend/internal/jobs/jobs.go
+++ b/backend/internal/jobs/jobs.go
@@ -10,12 +10,11 @@ import (
 type Status string
 
 const (
-	StatusQueued   Status = "queued"
-	StatusRunning  Status = "running"
-	StatusDone     Status = "done"
-	StatusError    Status = "error"
-	StatusTimeout  Status = "timeout"
-	StatusCanceled Status = "canceled"
+	StatusQueued    Status = "queued"
+	StatusRunning   Status = "running"
+	StatusDone      Status = "done"
+	StatusError     Status = "error"
+	StatusCancelled Status = "cancelled"
 )
 
 // RetryableError — сигнал воркеру, что ошибку можно/нужно ретраить.
@@ -124,7 +123,7 @@ func (q *Queue) StartWorkers(ctx context.Context, n int, runner Runner, maxAttem
 					delay = delay << t.Attempt
 					jitter := time.Duration(int64(delay) / 5)
 					if jitter > 0 {
-						delay += time.Duration(time.Now().UnixNano()%int64(jitter)) // простой джиттер
+						delay += time.Duration(time.Now().UnixNano() % int64(jitter)) // простой джиттер
 					}
 					t.Attempt++
 					q.EnqueueAfter(Default, t, delay)

--- a/backend/internal/worker/export_runner.go
+++ b/backend/internal/worker/export_runner.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"strings"
 	"time"
@@ -45,34 +45,37 @@ type Deps struct {
 	Store       *artifacts.FSStore
 	Exports     *store.ExportsMem
 	MaxAttempts int
-	Logger      *log.Logger
+	Logger      *slog.Logger
 }
 
 // NewRunner — адаптер под jobs.Runner.
 func NewRunner(d Deps) jobs.Runner {
 	return func(ctx context.Context, t jobs.Task) error {
-		lg := d.Logger
-		if lg == nil {
-			lg = log.Default()
-		}
-
 		p, ok := t.Payload.(ExportPayload)
 		if !ok {
-			d.Exports.UpdateStatus(t.ExportID, jobs.StatusError, 0, strPtr("invalid payload"))
+			logger := defaultLogger(d.Logger)
+			logger.Error("invalid payload", slog.String("exportId", t.ExportID))
+			d.Exports.UpdateStatus(t.ExportID, jobs.StatusError, 0, strPtr("invalid_payload"))
 			return nil
 		}
 		if d.MaxAttempts <= 0 {
 			d.MaxAttempts = 3
 		}
-
-		lg.Printf("export %s: start (attempt=%d) owner=%s repo=%s ref=%s format=%s profile=%s",
-			p.ExportID, t.Attempt+1, p.Owner, p.Repo, p.Ref, strings.ToLower(p.Format), p.Profile)
+		jobLog := loggerFor(d.Logger, p, t.Attempt)
+		jobLog.Info("export started",
+			slog.String("owner", p.Owner),
+			slog.String("repo", p.Repo),
+			slog.String("ref", p.Ref),
+			slog.String("format", strings.ToLower(p.Format)),
+			slog.String("profile", p.Profile),
+		)
 
 		// Создаём writer для артефакта (FSStore.CreateArtifact)
 		fileName := artifactFileName(p)
 		aw, meta, err := d.Store.CreateArtifact(p.ExportID, strings.ToLower(p.Format), fileName)
 		if err != nil {
-			d.Exports.UpdateStatus(p.ExportID, jobs.StatusError, 0, strPtr("cannot create artifact writer"))
+			jobLog.Error("cannot create artifact writer", slog.String("file", fileName), slog.String("error", err.Error()))
+			d.Exports.UpdateStatus(p.ExportID, jobs.StatusError, 0, strPtr("artifact_write_failed"))
 			return nil
 		}
 		closed := false
@@ -85,42 +88,47 @@ func NewRunner(d Deps) jobs.Runner {
 		d.Exports.UpdateStatus(p.ExportID, jobs.StatusRunning, 10, nil)
 
 		// 1) скачиваем tarball
+		if checkCancellation(ctx, d, p, jobLog, "before_tarball") {
+			return nil
+		}
+
 		rc, err := d.GH.GetTarball(ctx, p.Owner, p.Repo, p.Ref)
 		if err != nil {
 			var rle *githubclient.RateLimitedError
 			switch {
 			case errors.As(err, &rle):
-				lg.Printf("export %s: tarball rate-limited (attempt=%d) reset=%d err=%v",
-					p.ExportID, t.Attempt+1, rle.Reset, err)
+				jobLog.Warn("github rate limited",
+					slog.Int64("reset", rle.Reset),
+					slog.String("error", err.Error()),
+				)
 				delay := time.Until(time.Unix(rle.Reset, 0))
 				if delay < time.Second {
 					delay = time.Second
 				}
-				return retryOrFail("rate limited; retry later", "GitHub rate limited", delay)
+				return retryOrFail(d, jobLog, p, t.Attempt, d.MaxAttempts, "github_rate_limited", delay)
 
 			case errors.Is(err, githubclient.ErrUpstream):
-				lg.Printf("export %s: tarball upstream 5xx (attempt=%d) err=%v",
-					p.ExportID, t.Attempt+1, err)
-				return retryOrFail("upstream error; retry later", "GitHub 5xx", 2*time.Second)
+				jobLog.Warn("github upstream error",
+					slog.String("error", err.Error()),
+				)
+				return retryOrFail(d, jobLog, p, t.Attempt, d.MaxAttempts, "github_upstream_error", 2*time.Second)
 
 			case errors.Is(err, githubclient.ErrNotFound):
-				lg.Printf("export %s: tarball not found owner=%s repo=%s ref=%s err=%v",
-					p.ExportID, p.Owner, p.Repo, p.Ref, err)
-				d.Exports.UpdateStatus(p.ExportID, jobs.StatusError, 0, strPtr("repository or ref not found"))
+				jobLog.Info("repository or ref not found", slog.String("error", err.Error()))
+				d.Exports.UpdateStatus(p.ExportID, jobs.StatusError, 0, strPtr("github_not_found"))
 				return nil
 
 			default:
-				lg.Printf("export %s: tarball network error (attempt=%d) err=%v",
-					p.ExportID, t.Attempt+1, err)
-				return retryOrFail("network error; retry later", "network", 2*time.Second)
+				jobLog.Warn("github tarball network error", slog.String("error", err.Error()))
+				return retryOrFail(d, jobLog, p, t.Attempt, d.MaxAttempts, "github_network_error", 2*time.Second)
 			}
 		}
 
 		// --- Новый блок: стримим tarball во временный файл с прогрессом ---
 		tmpf, e := os.CreateTemp("", "tarball-*.tgz")
 		if e != nil {
-			lg.Printf("export %s: cannot create temp file: %v", p.ExportID, e)
-			d.Exports.UpdateStatus(p.ExportID, jobs.StatusError, 0, strPtr("cannot create temp file"))
+			jobLog.Error("cannot create temp file", slog.String("error", e.Error()))
+			d.Exports.UpdateStatus(p.ExportID, jobs.StatusError, 0, strPtr("temp_file_create_failed"))
 			_ = rc.Close()
 			return nil
 		}
@@ -144,8 +152,12 @@ func NewRunner(d Deps) jobs.Runner {
 		d.Exports.UpdateStatus(p.ExportID, jobs.StatusRunning, 12, nil)
 
 		for {
+			if checkCancellation(ctx, d, p, jobLog, "download_tarball") {
+				_ = rc.Close()
+				return nil
+			}
 			if written >= capBytes {
-				lg.Printf("export %s: tarball too large (> %d MB)", p.ExportID, maxDownloadMB)
+				jobLog.Warn("tarball too large", slog.Int("limitMB", maxDownloadMB))
 				d.Exports.UpdateStatus(p.ExportID, jobs.StatusError, 0, strPtr("too_large"))
 				_ = rc.Close()
 				return nil
@@ -158,8 +170,8 @@ func NewRunner(d Deps) jobs.Runner {
 			n, rerr := rc.Read(buf[:readCap])
 			if n > 0 {
 				if _, werr := tmpf.Write(buf[:n]); werr != nil {
-					lg.Printf("export %s: tarball write error: %v", p.ExportID, werr)
-					d.Exports.UpdateStatus(p.ExportID, jobs.StatusError, 0, strPtr("write error"))
+					jobLog.Error("tarball write error", slog.String("error", werr.Error()))
+					d.Exports.UpdateStatus(p.ExportID, jobs.StatusError, 0, strPtr("tarball_write_error"))
 					_ = rc.Close()
 					return nil
 				}
@@ -179,20 +191,20 @@ func NewRunner(d Deps) jobs.Runner {
 				if rerr == io.EOF {
 					break
 				}
-				lg.Printf("export %s: tarball read error: %v", p.ExportID, rerr)
+				jobLog.Warn("tarball read error", slog.String("error", rerr.Error()))
 				_ = rc.Close()
-				return retryOrFail("network error; retry later", "network-read", 2*time.Second)
+				return retryOrFail(d, jobLog, p, t.Attempt, d.MaxAttempts, "tarball_read_error", 2*time.Second)
 			}
 		}
 
 		if err := rc.Close(); err != nil {
-			lg.Printf("export %s: tarball close error: %v", p.ExportID, err)
+			jobLog.Warn("tarball close error", slog.String("error", err.Error()))
 			// не фатально для нас — продолжаем
 		}
 
 		if _, err := tmpf.Seek(0, io.SeekStart); err != nil {
-			lg.Printf("export %s: temp seek error: %v", p.ExportID, err)
-			d.Exports.UpdateStatus(p.ExportID, jobs.StatusError, 0, strPtr("temp file seek error"))
+			jobLog.Error("temp file seek error", slog.String("error", err.Error()))
+			d.Exports.UpdateStatus(p.ExportID, jobs.StatusError, 0, strPtr("temp_file_seek_failed"))
 			return nil
 		}
 		// заменяем rc на файл, дальше читаем из диска
@@ -200,6 +212,10 @@ func NewRunner(d Deps) jobs.Runner {
 		// завершили скачивание — переходим к следующему этапу
 		d.Exports.UpdateStatus(p.ExportID, jobs.StatusRunning, 32, nil)
 		// --- Конец нового блока ---
+
+		if checkCancellation(ctx, d, p, jobLog, "before_build") {
+			return nil
+		}
 
 		switch strings.ToLower(p.Format) {
 		case "zip":
@@ -213,12 +229,12 @@ func NewRunner(d Deps) jobs.Runner {
 			}
 			if err := exporter.BuildZipFromTarGz(rc, aw, opts); err != nil {
 				if err == exporter.ErrExportTooLarge {
-					lg.Printf("export %s: build zip too_large", p.ExportID)
+					jobLog.Warn("zip export too large")
 					d.Exports.UpdateStatus(p.ExportID, jobs.StatusError, 0, strPtr("too_large"))
 					return nil
 				}
-				lg.Printf("export %s: build zip failed (attempt=%d) err=%v", p.ExportID, t.Attempt+1, err)
-				return retryOrFail("build zip failed; retry", "build-zip", 2*time.Second)
+				jobLog.Warn("zip build failed", slog.String("error", err.Error()))
+				return retryOrFail(d, jobLog, p, t.Attempt, d.MaxAttempts, "zip_build_failed", 2*time.Second)
 			}
 
 		case "txt":
@@ -234,12 +250,12 @@ func NewRunner(d Deps) jobs.Runner {
 			}
 			if err := exporter.BuildTxtFromTarGz(rc, aw, topts); err != nil {
 				if err == exporter.ErrExportTooLarge {
-					lg.Printf("export %s: build txt too_large", p.ExportID)
+					jobLog.Warn("txt export too large")
 					d.Exports.UpdateStatus(p.ExportID, jobs.StatusError, 0, strPtr("too_large"))
 					return nil
 				}
-				lg.Printf("export %s: build txt failed (attempt=%d) err=%v", p.ExportID, t.Attempt+1, err)
-				return retryOrFail("build txt failed; retry", "build-txt", 2*time.Second)
+				jobLog.Warn("txt build failed", slog.String("error", err.Error()))
+				return retryOrFail(d, jobLog, p, t.Attempt, d.MaxAttempts, "txt_build_failed", 2*time.Second)
 			}
 
 		case "md":
@@ -258,36 +274,34 @@ func NewRunner(d Deps) jobs.Runner {
 			if err := exporter.BuildPromptPackFromTarGz(rc, aw, ppOpts); err != nil {
 				// Требуется второй проход
 				if need, ok := err.(*exporter.NeedSecondPassError); ok {
-					lg.Printf("export %s: promptpack need second pass", p.ExportID)
+					jobLog.Info("promptpack requires second pass")
 
 					rc2, e2 := d.GH.GetTarball(ctx, p.Owner, p.Repo, p.Ref)
 					if e2 != nil {
-						lg.Printf("export %s: second pass tarball error (attempt=%d) err=%v",
-							p.ExportID, t.Attempt+1, e2)
-						return retryOrFail("need second pass; tarball retry", "tarball-2nd", 2*time.Second)
+						jobLog.Warn("promptpack second pass tarball error", slog.String("error", e2.Error()))
+						return retryOrFail(d, jobLog, p, t.Attempt, d.MaxAttempts, "promptpack_second_pass_tarball", 2*time.Second)
 					}
 					defer rc2.Close()
 
 					if e := exporter.FillSecondPassExcerpts(rc2, need); e != nil {
-						lg.Printf("export %s: second pass failed (attempt=%d) err=%v",
-							p.ExportID, t.Attempt+1, e)
-						return retryOrFail("second pass failed; retry", "pp-second-pass", 2*time.Second)
+						jobLog.Warn("promptpack second pass failed", slog.String("error", e.Error()))
+						return retryOrFail(d, jobLog, p, t.Attempt, d.MaxAttempts, "promptpack_second_pass_failed", 2*time.Second)
 					}
 				} else {
-					lg.Printf("export %s: promptpack build failed (attempt=%d) err=%v",
-						p.ExportID, t.Attempt+1, err)
-					return retryOrFail("promptpack build failed; retry", "promptpack", 2*time.Second)
+					jobLog.Warn("promptpack build failed", slog.String("error", err.Error()))
+					return retryOrFail(d, jobLog, p, t.Attempt, d.MaxAttempts, "promptpack_build_failed", 2*time.Second)
 				}
 			}
 
 		default:
-			d.Exports.UpdateStatus(p.ExportID, jobs.StatusError, 0, strPtr("unknown format"))
+			jobLog.Error("unknown export format")
+			d.Exports.UpdateStatus(p.ExportID, jobs.StatusError, 0, strPtr("unknown_format"))
 			return nil
 		}
 
 		if err := aw.Close(); err != nil {
-			lg.Printf("export %s: artifact finalize error err=%v", p.ExportID, err)
-			d.Exports.UpdateStatus(p.ExportID, jobs.StatusError, 0, strPtr("cannot finalize artifact"))
+			jobLog.Error("artifact finalize error", slog.String("error", err.Error()))
+			d.Exports.UpdateStatus(p.ExportID, jobs.StatusError, 0, strPtr("artifact_finalize_failed"))
 			return nil
 		}
 		closed = true
@@ -300,18 +314,71 @@ func NewRunner(d Deps) jobs.Runner {
 			Kind: meta.Kind,
 			Size: meta.Size,
 		})
-		lg.Printf("export %s: done artifact=%s kind=%s size=%dB", p.ExportID, meta.ID, meta.Kind, meta.Size)
+		jobLog.Info("export completed",
+			slog.String("artifactId", meta.ID),
+			slog.String("artifactKind", meta.Kind),
+			slog.Int64("artifactSize", meta.Size),
+		)
 		d.Exports.UpdateStatus(p.ExportID, jobs.StatusDone, 100, nil)
 		return nil
 	}
 }
 
 // retryOrFail — простая стратегия повторов. (Очередь сама решает политику ретраев)
-func retryOrFail(msg, _ string, delay time.Duration) error {
+func retryOrFail(d Deps, log *slog.Logger, p ExportPayload, attempt, max int, failureReason string, delay time.Duration) error {
 	if delay <= 0 {
 		delay = 2 * time.Second
 	}
-	return fmt.Errorf("%s", msg)
+	if attempt+1 >= max {
+		log.Error("retry attempts exhausted", slog.String("failureReason", failureReason))
+		d.Exports.UpdateStatus(p.ExportID, jobs.StatusError, 0, strPtr(failureReason))
+		return nil
+	}
+	log.Warn("retry scheduled", slog.String("failureReason", failureReason), slog.Duration("delay", delay))
+	return &jobs.RetryableError{After: delay, Reason: failureReason}
+}
+
+func defaultLogger(lg *slog.Logger) *slog.Logger {
+	if lg != nil {
+		return lg
+	}
+	return slog.Default()
+}
+
+func loggerFor(lg *slog.Logger, p ExportPayload, attempt int) *slog.Logger {
+	base := defaultLogger(lg).With(
+		slog.String("exportId", p.ExportID),
+		slog.String("idemKey", p.IdempotencyKey),
+		slog.Int("attempt", attempt+1),
+		slog.String("format", strings.ToLower(p.Format)),
+		slog.String("profile", p.Profile),
+	)
+	if p.Owner != "" {
+		base = base.With(slog.String("owner", p.Owner))
+	}
+	if p.Repo != "" {
+		base = base.With(slog.String("repo", p.Repo))
+	}
+	if p.Ref != "" {
+		base = base.With(slog.String("ref", p.Ref))
+	}
+	return base
+}
+
+func checkCancellation(ctx context.Context, d Deps, p ExportPayload, log *slog.Logger, stage string) bool {
+	select {
+	case <-ctx.Done():
+		log.Warn("context cancelled", slog.String("stage", stage))
+		d.Exports.UpdateStatus(p.ExportID, jobs.StatusCancelled, -1, strPtr("context_cancelled"))
+		return true
+	default:
+	}
+	if d.Exports.IsCancelRequested(p.ExportID) {
+		log.Info("cancel requested", slog.String("stage", stage))
+		d.Exports.UpdateStatus(p.ExportID, jobs.StatusCancelled, -1, strPtr("user_cancelled"))
+		return true
+	}
+	return false
 }
 
 // hashID — утилита для стабильных идентификаторов.

--- a/figma/src/App.tsx
+++ b/figma/src/App.tsx
@@ -7,9 +7,7 @@ import { Jobs } from './components/pages/Jobs';
 import { Result } from './components/pages/Result';
 import { Topbar } from './components/organisms/Topbar';
 import { fetchRepositoryTree } from './lib/api';
-import { ArtifactFile, JobState, Page, RepoData, Theme, TreeItem } from './lib/types';
-
-type Language = 'ru' | 'en';
+import { ArtifactFile, JobState, Page, RepoData, Theme, TreeItem, Language } from './lib/types';
 
 interface AppContextType {
   theme: Theme;

--- a/figma/src/components/molecules/ExportForm.tsx
+++ b/figma/src/components/molecules/ExportForm.tsx
@@ -11,6 +11,7 @@ import { Separator } from '../ui/separator';
 import { Alert, AlertDescription } from '../ui/alert';
 import { Play, Settings, FileArchive, FileText, File, Loader2 } from 'lucide-react';
 import { ApiError, createExport } from '../../lib/api';
+import { getFriendlyApiError } from '../../lib/errors';
 
 export const ExportForm: React.FC = () => {
   const {
@@ -133,8 +134,8 @@ export const ExportForm: React.FC = () => {
         setCurrentPage('jobs');
       })
       .catch((err) => {
-        if (err instanceof ApiError && err.message) {
-          setError(err.message);
+        if (err instanceof ApiError) {
+          setError(getFriendlyApiError(err, language) ?? t.errors.generic);
           return;
         }
         setError(t.errors.generic);

--- a/figma/src/components/molecules/JobProgress.tsx
+++ b/figma/src/components/molecules/JobProgress.tsx
@@ -25,15 +25,17 @@ interface JobProgressProps {
   error?: string | null;
   onCancel: () => void;
   cancelDisabled?: boolean;
+  cancelRequested?: boolean;
 }
 
-export const JobProgress: React.FC<JobProgressProps> = ({ progress, jobId, state, error, onCancel, cancelDisabled }) => {
+export const JobProgress: React.FC<JobProgressProps> = ({ progress, jobId, state, error, onCancel, cancelDisabled, cancelRequested }) => {
   const { language } = useAppContext();
 
   const texts = {
     ru: {
       progress: 'Прогресс',
       cancel: 'Отменить',
+      canceling: 'Отменяем…',
       stages: [
         'Подготовка',
         'Скачивание',
@@ -55,7 +57,6 @@ export const JobProgress: React.FC<JobProgressProps> = ({ progress, jobId, state
       statusCompleted: 'Завершено',
       statusCanceled: 'Отменено',
       statusError: 'Ошибка',
-      statusTimeout: 'Таймаут',
       job: 'Задача',
       canceledNotice: 'Задача была отменена.',
       stagesTitle: 'Этапы выполнения',
@@ -63,6 +64,7 @@ export const JobProgress: React.FC<JobProgressProps> = ({ progress, jobId, state
     en: {
       progress: 'Progress',
       cancel: 'Cancel',
+      canceling: 'Cancelling…',
       stages: [
         'Preparation',
         'Downloading',
@@ -82,9 +84,8 @@ export const JobProgress: React.FC<JobProgressProps> = ({ progress, jobId, state
       statusPending: 'Pending',
       statusRunning: 'Running',
       statusCompleted: 'Completed',
-      statusCanceled: 'Canceled',
+      statusCanceled: 'Cancelled',
       statusError: 'Error',
-      statusTimeout: 'Timed out',
       job: 'Job',
       canceledNotice: 'The job was canceled.',
       stagesTitle: 'Execution stages',
@@ -154,16 +155,16 @@ export const JobProgress: React.FC<JobProgressProps> = ({ progress, jobId, state
         return <Badge variant="default">{t.statusRunning}</Badge>;
       case 'queued':
         return <Badge variant="outline">{t.statusPending}</Badge>;
-      case 'canceled':
+      case 'cancelled':
         return <Badge variant="outline">{t.statusCanceled}</Badge>;
-      case 'timeout':
-        return <Badge variant="destructive">{t.statusTimeout}</Badge>;
       case 'error':
         return <Badge variant="destructive">{t.statusError}</Badge>;
       default:
         return null;
     }
   };
+
+  const cancelButtonLabel = cancelRequested ? t.canceling : t.cancel;
 
   return (
     <div className="space-y-6">
@@ -192,10 +193,10 @@ export const JobProgress: React.FC<JobProgressProps> = ({ progress, jobId, state
               size="sm"
               onClick={onCancel}
               className="gap-2"
-              disabled={cancelDisabled || state !== 'running'}
+              disabled={cancelDisabled || cancelRequested || state !== 'running'}
             >
               <Square className="w-4 h-4" />
-              {t.cancel}
+              {cancelButtonLabel}
             </Button>
           </div>
         </CardContent>
@@ -240,7 +241,7 @@ export const JobProgress: React.FC<JobProgressProps> = ({ progress, jobId, state
         </Alert>
       )}
 
-      {state === 'canceled' && (
+      {state === 'cancelled' && (
         <Alert>
           <AlertDescription>{t.canceledNotice}</AlertDescription>
         </Alert>

--- a/figma/src/lib/api.ts
+++ b/figma/src/lib/api.ts
@@ -104,3 +104,24 @@ export const listArtifacts = (exportId: string): Promise<ArtifactsResponse> =>
   request<ArtifactsResponse>(`/api/artifacts/${encodeURIComponent(exportId)}`);
 
 export const getDownloadUrl = (artifactId: string): string => buildUrl(`/api/download/${encodeURIComponent(artifactId)}`);
+
+export const subscribeToJob = (
+  jobId: string,
+  onMessage: (payload: JobStatusResponse) => void,
+  onError?: (event: Event) => void,
+): EventSource => {
+  const url = buildUrl(`/api/jobs/${encodeURIComponent(jobId)}/events`);
+  const source = new EventSource(url);
+  source.onmessage = (event) => {
+    try {
+      const payload = JSON.parse(event.data) as JobStatusResponse;
+      onMessage(payload);
+    } catch (err) {
+      console.error('Failed to parse job event', err);
+    }
+  };
+  if (onError) {
+    source.onerror = onError;
+  }
+  return source;
+};

--- a/figma/src/lib/errors.ts
+++ b/figma/src/lib/errors.ts
@@ -1,0 +1,87 @@
+import { ApiError } from './api';
+import { Language } from './types';
+
+const friendlyMessages: Record<Language, Record<string, string>> = {
+  en: {
+    rate_limited: 'GitHub rate limit reached. Please retry in a few minutes.',
+    github_rate_limited: 'GitHub rate limit reached. Please retry in a few minutes.',
+    github_upstream_error: 'GitHub returned a server error. Please retry later.',
+    github_not_found: 'Repository or ref not found. Check the repository URL and branch.',
+    github_network_error: 'Network error while downloading the repository. Please retry.',
+    tarball_read_error: 'Network error while downloading the repository. Please retry.',
+    tarball_write_error: 'Failed to store the downloaded repository. Please retry.',
+    temp_file_create_failed: 'Failed to create a temporary file for the download.',
+    temp_file_seek_failed: 'Temporary file handling failed.',
+    artifact_write_failed: 'Failed to create the export artifact.',
+    artifact_finalize_failed: 'Failed to finalize the export artifact.',
+    zip_build_failed: 'Failed to assemble the ZIP archive. Please retry.',
+    txt_build_failed: 'Failed to assemble the text export. Please retry.',
+    promptpack_build_failed: 'Failed to generate the prompt pack. Please retry.',
+    promptpack_second_pass_tarball: 'Unable to download the repository for the prompt pack. Please retry later.',
+    promptpack_second_pass_failed: 'Prompt pack generation failed on the second pass. Please retry.',
+    too_large: 'Export exceeds the size limit. Narrow the selection or adjust filters.',
+    unknown_format: 'Unknown export format.',
+    invalid_payload: 'Internal exporter error.',
+    user_cancelled: 'Export was cancelled.',
+    context_cancelled: 'Export was cancelled by the system.',
+    not_found: 'Resource not found.',
+    network: 'Network error. Check your connection and retry.',
+    timeout: 'Request timed out. Please retry.',
+    conflict: 'Job has already finished.',
+  },
+  ru: {
+    rate_limited: 'Достигнут лимит GitHub. Повторите попытку через несколько минут.',
+    github_rate_limited: 'Достигнут лимит GitHub. Повторите попытку через несколько минут.',
+    github_upstream_error: 'GitHub вернул ошибку сервера. Попробуйте позже.',
+    github_not_found: 'Репозиторий или ветка не найдены. Проверьте URL и ветку.',
+    github_network_error: 'Сетевая ошибка при скачивании репозитория. Повторите попытку.',
+    tarball_read_error: 'Сетевая ошибка при скачивании репозитория. Повторите попытку.',
+    tarball_write_error: 'Не удалось сохранить скачанный архив. Повторите попытку.',
+    temp_file_create_failed: 'Не удалось создать временный файл для скачивания.',
+    temp_file_seek_failed: 'Ошибка работы с временным файлом.',
+    artifact_write_failed: 'Не удалось создать файл экспорта.',
+    artifact_finalize_failed: 'Не удалось завершить запись файла экспорта.',
+    zip_build_failed: 'Не удалось собрать ZIP-архив. Повторите попытку.',
+    txt_build_failed: 'Не удалось собрать текстовый экспорт. Повторите попытку.',
+    promptpack_build_failed: 'Не удалось собрать prompt pack. Повторите попытку.',
+    promptpack_second_pass_tarball: 'Не удалось повторно скачать репозиторий для prompt pack. Попробуйте позже.',
+    promptpack_second_pass_failed: 'Сбой на втором проходе генерации prompt pack. Повторите попытку.',
+    too_large: 'Экспорт превышает лимит размера. Сузьте выбор или измените фильтры.',
+    unknown_format: 'Неизвестный формат экспорта.',
+    invalid_payload: 'Внутренняя ошибка экспортера.',
+    user_cancelled: 'Экспорт отменён пользователем.',
+    context_cancelled: 'Экспорт отменён системой.',
+    not_found: 'Ресурс не найден.',
+    network: 'Сетевая ошибка. Проверьте соединение и повторите попытку.',
+    timeout: 'Истек таймаут запроса. Повторите попытку.',
+    conflict: 'Задача уже завершена.',
+  },
+};
+
+const defaultFailureMessage: Record<Language, string> = {
+  en: 'Export failed. Please retry later.',
+  ru: 'Экспорт завершился ошибкой. Попробуйте ещё раз позже.',
+};
+
+export const getFriendlyMessage = (code: string | null | undefined, language: Language): string | null => {
+  if (!code) {
+    return null;
+  }
+  const dict = friendlyMessages[language] ?? friendlyMessages.en;
+  return dict[code] ?? null;
+};
+
+export const getFriendlyApiError = (error: ApiError, language: Language): string => {
+  const friendly = getFriendlyMessage(error.code, language);
+  if (friendly) {
+    return friendly;
+  }
+  return error.message ?? (language === 'ru' ? 'Не удалось выполнить запрос.' : 'Request failed.');
+};
+
+export const getFriendlyFailureReason = (reason: string | null | undefined, language: Language): string | null => {
+  if (!reason) {
+    return null;
+  }
+  return getFriendlyMessage(reason, language) ?? defaultFailureMessage[language];
+};

--- a/figma/src/lib/types.ts
+++ b/figma/src/lib/types.ts
@@ -1,5 +1,6 @@
 export type Theme = 'light' | 'dark';
 export type Page = 'landing' | 'analyze' | 'select' | 'export' | 'jobs' | 'result';
+export type Language = 'ru' | 'en';
 
 export interface RepoData {
   url: string;
@@ -69,7 +70,7 @@ export interface ExportResponse {
   jobId: string;
 }
 
-export type JobStatus = 'queued' | 'running' | 'done' | 'error' | 'timeout' | 'canceled';
+export type JobStatus = 'queued' | 'running' | 'done' | 'error' | 'cancelled';
 
 export interface JobStatusResponse {
   state: JobStatus;
@@ -77,6 +78,8 @@ export interface JobStatusResponse {
   error?: string | null;
   exportId?: string;
   artifacts?: Array<{ id: string; kind: string; size: number }>;
+  failureReason?: string | null;
+  cancelRequested?: boolean;
 }
 
 export interface JobState {
@@ -85,6 +88,8 @@ export interface JobState {
   progress: number;
   error?: string | null;
   exportId?: string;
+  failureReason?: string | null;
+  cancelRequested?: boolean;
 }
 
 export interface ArtifactFile {


### PR DESCRIPTION
## Summary
- add ExportSnapshot subscriptions, SSE job events, and cancellable status handling with new failureReason fields
- switch worker and HTTP stack to structured slog logging with retry-aware cancellation
- add include/exclude and size limit tests for zip/txt exporters plus front-end SSE progress stream and friendly errors

## Testing
- go test ./...
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d46e72276c832ca3f30c7634a4f503