### PR TITLE
Refactor dependencies to interfaces and add tooling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Copy to .env and adjust values as needed
+PORT=8080
+REQUEST_TIMEOUT=15s
+ENV=dev
+GITHUB_TOKEN=ghp_example_token

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ coverage/
 data/
 backend/data/
 artifacts/
+!backend/internal/artifacts/
 
 # --- Frontend (Vite / Node) ---
 figma/node_modules/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: run build test fmt lint
+
+run:
+	cd backend && go run ./cmd/api
+
+build:
+	cd backend && go build ./cmd/api
+
+test:
+	cd backend && go test ./...
+
+fmt:
+	cd backend && gofmt -w $$(go list -f '{{.Dir}}' ./...)
+
+lint:
+	cd backend && go vet ./...

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,32 @@
+version: '3'
+
+tasks:
+  run:
+    desc: Run the API server
+    dir: backend
+    cmds:
+      - go run ./cmd/api
+
+  build:
+    desc: Build the API binary
+    dir: backend
+    cmds:
+      - go build ./cmd/api
+
+  test:
+    desc: Run Go tests
+    dir: backend
+    cmds:
+      - go test ./...
+
+  fmt:
+    desc: Format Go sources
+    dir: backend
+    cmds:
+      - gofmt -w $$(go list -f '{{.Dir}}' ./...)
+
+  lint:
+    desc: Run basic static analysis
+    dir: backend
+    cmds:
+      - go vet ./...

--- a/backend/internal/artifacts/interfaces.go
+++ b/backend/internal/artifacts/interfaces.go
@@ -1,0 +1,14 @@
+package artifacts
+
+import (
+	"os"
+	"time"
+)
+
+// ArtifactsStore описывает хранилище артефактов экспорта.
+type ArtifactsStore interface {
+	IsSafeID(id string) bool
+	CreateArtifact(exportID, kind, name string) (*ArtifactWriter, ArtifactMeta, error)
+	OpenByArtifactID(artifactID string) (*os.File, ArtifactMeta, string, error)
+	ListByExportID(exportID string) ([]ArtifactMeta, time.Time, error)
+}

--- a/backend/internal/handlers/artifacts.go
+++ b/backend/internal/handlers/artifacts.go
@@ -13,7 +13,7 @@ import (
 
 // ArtifactsListHandler — GET /api/artifacts/:exportId → список файлов + expiresAt.
 type ArtifactsListHandler struct {
-	Store *artifacts.FSStore
+	Store artifacts.ArtifactsStore
 }
 
 func lastPathSegment(p string) string {

--- a/backend/internal/handlers/download.go
+++ b/backend/internal/handlers/download.go
@@ -12,10 +12,12 @@ import (
 
 // DownloadHandler — GET /api/download/:artifactId → отдаёт файл (стримом).
 type DownloadHandler struct {
-	Store *artifacts.FSStore
+	Store artifacts.ArtifactsStore
 }
 
-func NewDownloadHandler(st *artifacts.FSStore) *DownloadHandler { return &DownloadHandler{Store: st} }
+func NewDownloadHandler(st artifacts.ArtifactsStore) *DownloadHandler {
+	return &DownloadHandler{Store: st}
+}
 
 func (h *DownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {

--- a/backend/internal/handlers/export.go
+++ b/backend/internal/handlers/export.go
@@ -18,10 +18,10 @@ import (
 // Для production-режима рекомендуем использовать /api/export (async).
 type ExportHandler struct {
 	GH    *githubclient.Client
-	Store *artifacts.FSStore
+	Store artifacts.ArtifactsStore
 }
 
-func NewExportHandler(gh *githubclient.Client, st *artifacts.FSStore) *ExportHandler {
+func NewExportHandler(gh *githubclient.Client, st artifacts.ArtifactsStore) *ExportHandler {
 	return &ExportHandler{GH: gh, Store: st}
 }
 

--- a/backend/internal/handlers/export_async.go
+++ b/backend/internal/handlers/export_async.go
@@ -17,8 +17,8 @@ const exporterVersion = "v0.10.0"
 
 // ExportAsyncHandler — POST /api/export → ставит задачу в очередь и возвращает jobId.
 type ExportAsyncHandler struct {
-	Queue   *jobs.Queue
-	Exports *store.ExportsMem
+	Queue   jobs.JobsQueue
+	Exports store.ExportsStore
 	GH      *githubclient.Client
 }
 

--- a/backend/internal/handlers/jobs.go
+++ b/backend/internal/handlers/jobs.go
@@ -13,7 +13,7 @@ import (
 
 // JobStatusHandler — GET /api/jobs/:id
 type JobStatusHandler struct {
-	Exports *store.ExportsMem
+	Exports store.ExportsStore
 }
 
 func (h *JobStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -36,7 +36,7 @@ func (h *JobStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // JobCancelHandler — POST /api/jobs/:id/cancel
 type JobCancelHandler struct {
-	Exports *store.ExportsMem
+	Exports store.ExportsStore
 }
 
 func (h *JobCancelHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -59,7 +59,7 @@ func (h *JobCancelHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // JobEventsHandler — SSE стрим обновлений статуса.
 type JobEventsHandler struct {
-	Exports *store.ExportsMem
+	Exports store.ExportsStore
 	Logger  *slog.Logger
 }
 

--- a/backend/internal/jobs/interfaces.go
+++ b/backend/internal/jobs/interfaces.go
@@ -1,0 +1,13 @@
+package jobs
+
+import (
+	"context"
+	"time"
+)
+
+// JobsQueue описывает очередь задач экспорта.
+type JobsQueue interface {
+	Enqueue(p Priority, t Task)
+	EnqueueAfter(p Priority, t Task, d time.Duration)
+	StartWorkers(ctx context.Context, n int, runner Runner, maxAttempts int)
+}

--- a/backend/internal/store/interfaces.go
+++ b/backend/internal/store/interfaces.go
@@ -1,0 +1,15 @@
+package store
+
+import "github.com/yourname/cleanhttp/internal/jobs"
+
+// ExportsStore описывает поведение хранилища экспортов.
+type ExportsStore interface {
+	CreateOrReuse(owner, repo, ref string, opts ExportOptions) (*Export, bool)
+	Get(id string) (*Export, bool)
+	UpdateStatus(id string, st jobs.Status, progress int, failureReason *string)
+	SetProgress(id string, progress int)
+	AddArtifact(id string, art ArtifactMeta)
+	RequestCancel(id string) bool
+	IsCancelRequested(id string) bool
+	Subscribe(id string) (<-chan ExportSnapshot, func(), bool)
+}

--- a/backend/internal/worker/export_runner.go
+++ b/backend/internal/worker/export_runner.go
@@ -42,8 +42,8 @@ type ExportPayload struct {
 // Deps — зависимости раннера.
 type Deps struct {
 	GH          *githubclient.Client
-	Store       *artifacts.FSStore
-	Exports     *store.ExportsMem
+	Store       artifacts.ArtifactsStore
+	Exports     store.ExportsStore
 	MaxAttempts int
 	Logger      *slog.Logger
 }


### PR DESCRIPTION
## Summary
- add interfaces for artifacts store, exports store, and jobs queue and refactor handlers, worker, and router to consume abstractions
- retain in-memory implementations as defaults while preparing dependency injection through router wiring
- provide developer tooling via Makefile, Taskfile, and example environment file while adjusting .gitignore

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d583ccbba0832c97536a89622023a0