### PR TITLE
Add job identifier to async export response

### DIFF
--- a/backend/internal/handlers/export_async.go
+++ b/backend/internal/handlers/export_async.go
@@ -18,7 +18,7 @@ type EnqueueOnly interface {
 }
 
 type ExportAsyncHandler struct {
-	Queue   EnqueueOnly          // ← было: jobs.JobsQueue
+	Queue   EnqueueOnly // ← было: jobs.JobsQueue
 	Exports store.ExportsStore
 	GH      *githubclient.Client
 }
@@ -100,6 +100,7 @@ func (h *ExportAsyncHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	_ = json.NewEncoder(w).Encode(map[string]any{
+		"jobId":    exp.ID,
 		"exportId": exp.ID,
 		"status":   exp.Status,
 	})


### PR DESCRIPTION
## Summary
- update the async export handler so the JSON response contains a jobId alongside the existing exportId
- keep exportId for backwards compatibility while unblocking clients expecting a job identifier

## Testing
- go test ./... *(fails: command hung in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d90dbbfdc0832c89f39a00e9158973