### PR TITLE
Initialize Postgres schema for exports store at startup

### DIFF
--- a/backend/internal/storepg/exports_pg.go
+++ b/backend/internal/storepg/exports_pg.go
@@ -6,8 +6,6 @@ import (
 	"errors"
 	"time"
 
-	
-
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/yourname/cleanhttp/internal/jobs"
 	"github.com/yourname/cleanhttp/internal/store"
@@ -34,6 +32,11 @@ func New(ctx context.Context, dbURL string) (*ExportsPG, error) {
 		pool.Close()
 		return nil, err
 	}
+	if err := ensureSchema(ctx, pool); err != nil {
+		pool.Close()
+		return nil, err
+	}
+
 	return &ExportsPG{pool: pool}, nil
 }
 

--- a/backend/internal/storepg/schema.go
+++ b/backend/internal/storepg/schema.go
@@ -1,0 +1,55 @@
+package storepg
+
+import (
+	"context"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const schemaInitSQL = `
+CREATE TABLE IF NOT EXISTS exports (
+  id                TEXT PRIMARY KEY,
+  user_id           TEXT,
+  project_id        TEXT,
+  owner             TEXT NOT NULL,
+  repo              TEXT NOT NULL,
+  ref               TEXT NOT NULL,
+  options           JSONB NOT NULL,
+  status            TEXT NOT NULL,
+  progress          INTEGER NOT NULL DEFAULT 0,
+  failure_reason    TEXT,
+  cancel_requested  BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  started_at        TIMESTAMPTZ,
+  finished_at       TIMESTAMPTZ,
+  idem_key          TEXT NOT NULL UNIQUE,
+  profile           TEXT,
+  format            TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_exports_created ON exports (created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_exports_status  ON exports (status);
+
+CREATE TABLE IF NOT EXISTS artifacts (
+  id           BIGSERIAL PRIMARY KEY,
+  export_id    TEXT NOT NULL REFERENCES exports(id) ON DELETE CASCADE,
+  name         TEXT NOT NULL,
+  path         TEXT NOT NULL,
+  content_type TEXT,
+  size         BIGINT,
+  checksum     TEXT,
+  meta         JSONB,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_artifacts_export ON artifacts (export_id);
+`
+
+func ensureSchema(ctx context.Context, pool *pgxpool.Pool) error {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	_, err := pool.Exec(ctx, schemaInitSQL)
+	return err
+}


### PR DESCRIPTION
## Summary
- run the exports schema initialization when creating the Postgres-backed exports repository
- add the schema creation SQL so workers and the API can persist export status

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d926808718832c97191824cf281176