### PR TITLE
Add background sync for export statuses

### DIFF
--- a/backend/internal/httpserver/router.go
+++ b/backend/internal/httpserver/router.go
@@ -55,6 +55,9 @@ func New(cfg config.Config) http.Handler {
 		}
 	}
 	exportsMem := store.NewExportsMemWithRepo("exp", repo)
+	if repo != nil {
+		exportsMem.StartSync(context.Background(), 2*time.Second)
+	}
 	var exportsStore store.ExportsStore = exportsMem
 
 	// Asynq producer


### PR DESCRIPTION
## Summary
- add background synchronization that keeps the in-memory export cache up to date with Postgres updates from the Redis worker
- update the HTTP server to start the sync loop whenever a Postgres repository is configured
- ensure export snapshots copy pointer fields safely when syncing from the repository

## Testing
- go test ./... *(hangs locally, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68d95a6ff098832c964a3f04159b79f0