### PR TITLE
Fix MinIO healthcheck to avoid missing curl

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -125,7 +125,11 @@ services:
     volumes:
       - minio_data:/data
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/ready"]
+      test:
+        [
+          "CMD-SHELL",
+          "wget -q --spider http://127.0.0.1:9000/minio/health/ready || (command -v curl >/dev/null 2>&1 && curl -fsS http://127.0.0.1:9000/minio/health/ready)",
+        ]
       interval: 5s
       timeout: 3s
       retries: 30


### PR DESCRIPTION
## Summary
- update the MinIO healthcheck to use a shell command that first tries wget and only falls back to curl when it is available
- keep the rest of the compose configuration unchanged so that dependent services continue to wait for a healthy MinIO instance

## Testing
- not run (compose-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d98310f4ac832c8c6022bbd3440060