### PR TITLE
Fix MinIO image tags in dev compose file

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -114,7 +114,7 @@ services:
         condition: service_healthy
 
   minio:
-    image: minio/minio:RELEASE.2025-01-20T00-00-00Z
+    image: minio/minio:RELEASE.2024-12-18T13-15-44Z
     command: server /data --console-address ":9001"
     environment:
       MINIO_ROOT_USER: rep2prompt
@@ -135,7 +135,7 @@ services:
       retries: 30
 
   minio-mc:
-    image: minio/mc:RELEASE.2025-01-20T00-00-00Z
+    image: minio/mc:RELEASE.2024-12-18T13-15-44Z
     depends_on:
       minio:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- update the MinIO server and client images in docker-compose.dev.yml to use an existing 2024 release tag
- ensure the development stack can pull the referenced MinIO images without manifest errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9b2effe88832c9abbbecccab39c3e