### PR TITLE
Preserve export progress after failures

### DIFF
--- a/backend/internal/store/exports_mem.go
+++ b/backend/internal/store/exports_mem.go
@@ -184,9 +184,17 @@ func (s *ExportsMem) UpdateStatus(id string, st jobs.Status, progress int, failu
 
 	s.mu.Lock()
 	if e, ok := s.byID[id]; ok {
+		prevProgress := e.Progress
 		e.Status = st
 		if progress >= 0 {
-			e.Progress = progress
+			switch st {
+			case jobs.StatusError, jobs.StatusCancelled:
+				if progress >= prevProgress {
+					e.Progress = progress
+				}
+			default:
+				e.Progress = progress
+			}
 		}
 		e.FailureReason = failureReason
 		now := time.Now().UTC()

--- a/backend/internal/storepg/exports_pg.go
+++ b/backend/internal/storepg/exports_pg.go
@@ -117,7 +117,11 @@ func (r *ExportsPG) UpdateStatus(ctx context.Context, id string, st jobs.Status,
 	const q = `
 UPDATE exports SET
   status = $2,
-  progress = $3,
+  progress = CASE
+                WHEN $3 < 0 THEN progress
+                WHEN $2 IN ('error','cancelled') AND $3 < progress THEN progress
+                ELSE $3
+             END,
   failure_reason = $4,
   started_at = COALESCE(started_at, CASE WHEN $2 = 'running' THEN NOW() ELSE NULL END),
   finished_at = CASE WHEN $2 IN ('done','error','cancelled') THEN NOW() ELSE finished_at END


### PR DESCRIPTION
## Summary
- prevent the in-memory export store from decreasing recorded progress when a job ends in an error or is cancelled
- adjust the Postgres update statement so terminal job states retain the last known progress instead of resetting to zero

## Testing
- go test ./... *(hangs locally, cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68dbed0ec22c832cad3b6deda7878184