### PR TITLE
Fix export tarball cancellation handling

### DIFF
--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -167,7 +167,12 @@ func main() {
 		// 1) скачать tarball из GitHub
 		dctx, cancel := context.WithTimeout(ctx, 3*time.Minute)
 		rc, err := gh.GetTarball(dctx, owner, repo, ref)
-		cancel()
+		if err != nil {
+			cancel()
+		} else {
+			// Отменяем контекст после завершения обработки tarball (закроется в defer).
+			defer cancel()
+		}
 		if err != nil {
 			// Разрулим типичные кейсы: 404/401 → «ресурс не найден / нет доступа»
 			msg := friendlyGhError(err, owner, repo, ref)


### PR DESCRIPTION
## Summary
- avoid cancelling the GitHub tarball request before the worker finishes streaming it
- defer the cancellation so the context is cleaned up only after the tarball is processed

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dbfd57c948832c857e55d9f8397c14