### PR TITLE
Fix promptpack export normalization

### DIFF
--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -145,10 +145,7 @@ func main() {
 		}
 		jobLog := logger.With(slog.String("export_id", p.ExportID))
 
-		format := strings.ToLower(strings.TrimSpace(p.Format))
-		if format == "" {
-			format = "zip"
-		}
+		format := normalizeFormat(p.Format)
 
 		// mark running
 		expStore.UpdateStatus(p.ExportID, jobs.StatusRunning, 1, nil)
@@ -352,6 +349,17 @@ func normalizeRef(ref string) string {
 	r = strings.TrimPrefix(r, "refs/heads/")
 	r = strings.TrimPrefix(r, "heads/")
 	return r
+}
+
+func normalizeFormat(format string) string {
+	f := strings.ToLower(strings.TrimSpace(format))
+	if f == "" {
+		return "zip"
+	}
+	if f == "md" {
+		return "promptpack"
+	}
+	return f
 }
 
 // Преобразуем ошибки GitHub в дружелюбные сообщения на RU

--- a/backend/internal/handlers/export.go
+++ b/backend/internal/handlers/export.go
@@ -71,7 +71,10 @@ func (h *ExportHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if in.Format == "" {
 		in.Format = "zip"
 	}
-	in.Format = strings.ToLower(in.Format)
+	in.Format = strings.ToLower(strings.TrimSpace(in.Format))
+	if in.Format == "md" {
+		in.Format = "promptpack"
+	}
 	switch in.Format {
 	case "zip", "txt", "promptpack":
 	default:

--- a/backend/internal/handlers/export_async.go
+++ b/backend/internal/handlers/export_async.go
@@ -63,6 +63,14 @@ func (h *ExportAsyncHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if req.Ref == "" {
 		req.Ref = "main"
 	}
+	format := strings.ToLower(strings.TrimSpace(req.Format))
+	if format == "" {
+		format = "zip"
+	}
+	if format == "md" {
+		format = "promptpack"
+	}
+	req.Format = format
 
 	exp, _ := h.Exports.CreateOrReuse(req.Owner, req.Repo, req.Ref, store.ExportOptions{
 		IncludeGlobs:    req.IncludeGlobs,

--- a/backend/internal/store/exports_mem.go
+++ b/backend/internal/store/exports_mem.go
@@ -20,7 +20,7 @@ type ExportOptions struct {
 	TTLHours        int
 	MaxBinarySizeMB int
 	Profile         string // short|full|rag
-	Format          string // zip|md|txt
+	Format          string // zip|txt|promptpack (md legacy alias)
 	IdempotencyKey  string
 }
 


### PR DESCRIPTION
## Summary
- normalize export format strings in the worker so the legacy `md` alias is treated as `promptpack`
- coerce prompt pack exports in the sync and async handlers and clarify stored export options
- align the async export runner with the canonical format handling helpers

## Testing
- `go test ./...` *(fails: directory prefix . does not contain main module or its selected dependencies)*
- `cd backend && go test ./...` *(interrupted due to long compilation in the current container)*

------
https://chatgpt.com/codex/tasks/task_e_68de7794b6bc832cb2b7d250cd57fe6a