### PR TITLE
Restore unauthenticated analysis flow on landing page

### DIFF
--- a/figma/src/components/organisms/TreeSelector.tsx
+++ b/figma/src/components/organisms/TreeSelector.tsx
@@ -8,7 +8,8 @@ import { Checkbox } from '../ui/checkbox';
 import { Badge } from '../ui/badge';
 import { ScrollArea } from '../ui/scroll-area';
 import { Separator } from '../ui/separator';
-import { Search, Folder, File, FolderOpen, RefreshCw } from 'lucide-react';
+import { Alert, AlertDescription } from '../ui/alert';
+import { Search, Folder, File, FolderOpen, RefreshCw, AlertCircle } from 'lucide-react';
 import { formatBytes } from '../../lib/utils';
 import { TreeItem } from '../../lib/types';
 import { collectFilePaths, createGlobMatcher, filterTreeByGlobs } from '../../lib/glob';
@@ -34,6 +35,8 @@ export const TreeSelector: React.FC<TreeSelectorProps> = ({ selectedFiles, onSel
     treeItems,
     treeLoading,
     repoData,
+    treeSource,
+    treeError,
     loadTree,
     includeMasks,
     excludeMasks,
@@ -65,6 +68,34 @@ export const TreeSelector: React.FC<TreeSelectorProps> = ({ selectedFiles, onSel
   };
 
   const t = texts[language];
+
+  useEffect(() => {
+    if (!repoData) {
+      return;
+    }
+
+    const { owner, repo, currentRef } = repoData;
+    const matchesCurrentSource =
+      treeSource &&
+      treeSource.owner === owner &&
+      treeSource.repo === repo &&
+      treeSource.ref === currentRef;
+
+    if (!matchesCurrentSource || treeItems.length === 0) {
+      loadTree(owner, repo, currentRef).catch(() => {
+        /* error is surfaced via treeError */
+      });
+    }
+  }, [
+    repoData?.owner,
+    repoData?.repo,
+    repoData?.currentRef,
+    treeSource?.owner,
+    treeSource?.repo,
+    treeSource?.ref,
+    treeItems.length,
+    loadTree,
+  ]);
 
   const tree = useMemo(() => {
     if (!treeItems.length) {
@@ -393,6 +424,13 @@ export const TreeSelector: React.FC<TreeSelectorProps> = ({ selectedFiles, onSel
   return (
     <div className="grid lg:grid-cols-2 gap-6">
       <div className="space-y-4">
+        {treeError && (
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertDescription>{treeError}</AlertDescription>
+          </Alert>
+        )}
+
         <div className="flex items-center gap-2">
           <div className="relative flex-1">
             <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-muted-foreground" />

--- a/figma/src/components/pages/Analyze.tsx
+++ b/figma/src/components/pages/Analyze.tsx
@@ -28,6 +28,8 @@ export const Analyze: React.FC = () => {
     return null;
   }
 
+  const hasStats = Boolean(repoData.stats);
+
   return (
     <div className="min-h-screen bg-background">
       <div className="container mx-auto px-4 py-8 max-w-6xl">
@@ -35,11 +37,11 @@ export const Analyze: React.FC = () => {
           <div>
             <h1 className="text-3xl font-bold mb-2">{t.title}</h1>
             <p className="text-muted-foreground">
-              {repoData.owner}/{repoData.name}
+              {repoData.owner}/{repoData.repo}
             </p>
           </div>
-          
-          <Button 
+
+          <Button
             variant="ghost" 
             onClick={() => setCurrentPage('landing')}
             className="gap-2"
@@ -51,11 +53,30 @@ export const Analyze: React.FC = () => {
 
         <div className="space-y-6">
           <RefSelector />
-          
-          <AnalyticsSummary stats={repoData.stats} />
-          
+
+          {hasStats ? (
+            <AnalyticsSummary stats={repoData.stats!} />
+          ) : (
+            <div className="grid md:grid-cols-3 gap-6">
+              {[0, 1, 2].map((index) => (
+                <div
+                  key={index}
+                  className="rounded-lg border border-dashed border-border bg-muted/40 p-6 text-sm text-muted-foreground"
+                >
+                  <div className="h-4 w-24 rounded bg-muted mb-3 animate-pulse" />
+                  <div className="h-8 w-32 rounded bg-muted animate-pulse" />
+                  <p className="mt-4 text-xs">
+                    {language === 'ru'
+                      ? 'Статистика будет доступна после первого анализа.'
+                      : 'Statistics will appear after the initial analysis.'}
+                  </p>
+                </div>
+              ))}
+            </div>
+          )}
+
           {repoData.warnings?.length > 0 && (
-            <WarningBanner 
+            <WarningBanner
               type="warning"
               title="Найдены предупреждения"
               warnings={repoData.warnings}


### PR DESCRIPTION
## Summary
- keep the landing analyze page usable without stats data and show the resolved repository slug
- sync the select page with shared selection state, compute the selected size, and block access when no repo is resolved
- auto-load the repository tree for the current repo and expose loading errors to the user

## Testing
- npm run build *(fails: Rollup could not resolve react-router-dom in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dea37896c4832c970754f219fdef13