### PR TITLE
Fix artifact list rendering for exports

### DIFF
--- a/figma/src/components/molecules/ArtifactsList.tsx
+++ b/figma/src/components/molecules/ArtifactsList.tsx
@@ -11,6 +11,8 @@ interface ArtifactsListProps {
   artifacts: ArtifactFile[];
 }
 
+const normalizeType = (type?: string) => type?.toLowerCase() ?? 'other';
+
 export const ArtifactsList: React.FC<ArtifactsListProps> = ({ artifacts }) => {
   const { language } = useAppContext();
 
@@ -29,8 +31,8 @@ export const ArtifactsList: React.FC<ArtifactsListProps> = ({ artifacts }) => {
 
   const t = texts[language];
 
-  const getFileIcon = (type: string) => {
-    switch (type) {
+  const getFileIcon = (type?: string) => {
+    switch (normalizeType(type)) {
       case 'zip':
         return <FileArchive className="w-5 h-5 text-orange-500" />;
       case 'md':
@@ -42,21 +44,26 @@ export const ArtifactsList: React.FC<ArtifactsListProps> = ({ artifacts }) => {
     }
   };
 
-  const getFileTypeBadge = (type: string) => {
+  const getFileTypeBadge = (type?: string) => {
+    const normalizedType = normalizeType(type);
     const colors = {
       zip: 'bg-orange-100 text-orange-800',
       md: 'bg-blue-100 text-blue-800',
       txt: 'bg-gray-100 text-gray-800',
+      other: 'bg-gray-100 text-gray-800',
     };
 
     return (
-      <Badge variant="secondary" className={colors[type as keyof typeof colors] ?? 'bg-gray-100 text-gray-800'}>
-        {type.toUpperCase()}
+      <Badge variant="secondary" className={colors[normalizedType as keyof typeof colors] ?? colors.other}>
+        {normalizedType.toUpperCase()}
       </Badge>
     );
   };
 
   const handleDownload = (artifact: ArtifactFile) => {
+    if (!artifact.downloadUrl) {
+      return;
+    }
     window.open(artifact.downloadUrl, '_blank', 'noopener');
   };
 

--- a/figma/src/components/pages/Result.tsx
+++ b/figma/src/components/pages/Result.tsx
@@ -4,6 +4,7 @@ import { ArtifactsList } from '../molecules/ArtifactsList';
 import { Button } from '../ui/button';
 import { Alert, AlertDescription } from '../ui/alert';
 import { CheckCircle2, Plus } from 'lucide-react';
+import { ArtifactFile } from '../../lib/types';
 
 export const Result: React.FC = () => {
   const { language, setCurrentPage } = useAppContext();
@@ -27,27 +28,27 @@ export const Result: React.FC = () => {
 
   const t = texts[language];
 
-  const mockArtifacts = [
+  const mockArtifacts: ArtifactFile[] = [
     {
       id: '1',
       name: 'PromptPack-Short.md',
-      type: 'md' as const,
-      size: '128 KB',
-      url: '#',
+      kind: 'md',
+      size: 131072,
+      downloadUrl: '#',
     },
     {
-      id: '2', 
+      id: '2',
       name: 'Export.zip',
-      type: 'zip' as const,
-      size: '14.2 MB',
-      url: '#',
+      kind: 'zip',
+      size: 14876672,
+      downloadUrl: '#',
     },
     {
       id: '3',
       name: 'Concat.txt',
-      type: 'txt' as const,
-      size: '1.3 MB', 
-      url: '#',
+      kind: 'txt',
+      size: 1363149,
+      downloadUrl: '#',
     },
   ];
 


### PR DESCRIPTION
## Summary
- guard artifact list rendering against missing file type metadata
- align result page mock artifacts with the ArtifactFile schema to avoid runtime errors

## Testing
- npm run build *(fails: missing react-router-dom dependency in node_modules)*

------
https://chatgpt.com/codex/tasks/task_e_68deaaede92c832cbd46dd9f511e738e