### PR TITLE
Fix export flow preview and job tracking

### DIFF
--- a/figma/src/App.tsx
+++ b/figma/src/App.tsx
@@ -40,6 +40,7 @@ import {
   Language,
   Page,
   RepoData,
+  ExportFormat,
   Theme,
   TreeItem,
   User,
@@ -61,6 +62,7 @@ interface AppContextType {
   currentJob: JobState | null;
   artifacts: ArtifactFile[];
   artifactsExpiresAt: string | null;
+  lastExportFormat: ExportFormat | null;
   user: User | null;
   isAuthenticated: boolean;
   setTheme: (theme: Theme) => void;
@@ -78,6 +80,7 @@ interface AppContextType {
   setCurrentJob: React.Dispatch<React.SetStateAction<JobState | null>>;
   setArtifacts: React.Dispatch<React.SetStateAction<ArtifactFile[]>>;
   setArtifactsExpiresAt: React.Dispatch<React.SetStateAction<string | null>>;
+  setLastExportFormat: React.Dispatch<React.SetStateAction<ExportFormat | null>>;
   loadTree: (
     owner: string,
     repo: string,
@@ -167,6 +170,9 @@ export default function App() {
   const [currentJob, setCurrentJob] = useState<JobState | null>(null);
   const [artifacts, setArtifacts] = useState<ArtifactFile[]>([]);
   const [artifactsExpiresAt, setArtifactsExpiresAt] = useState<string | null>(
+    null,
+  );
+  const [lastExportFormat, setLastExportFormat] = useState<ExportFormat | null>(
     null,
   );
   const [user, setUser] = useState<User | null>(null);
@@ -263,6 +269,7 @@ export default function App() {
       currentJob,
       artifacts,
       artifactsExpiresAt,
+      lastExportFormat,
       user,
       isAuthenticated,
       setTheme,
@@ -278,6 +285,7 @@ export default function App() {
       setCurrentJob,
       setArtifacts,
       setArtifactsExpiresAt,
+      setLastExportFormat,
       loadTree,
       login,
       logout,
@@ -298,6 +306,7 @@ export default function App() {
       currentJob,
       artifacts,
       artifactsExpiresAt,
+      lastExportFormat,
       user,
       isAuthenticated,
       setCurrentPage,

--- a/figma/src/components/molecules/ExportForm.tsx
+++ b/figma/src/components/molecules/ExportForm.tsx
@@ -11,6 +11,7 @@ import { Separator } from '../ui/separator';
 import { Alert, AlertDescription } from '../ui/alert';
 import { Play, Settings, FileArchive, FileText, File, Loader2 } from 'lucide-react';
 import { ApiError, createExport } from '../../lib/api';
+import { ExportFormat } from '../../lib/types';
 import { getFriendlyApiError } from '../../lib/errors';
 
 export const ExportForm: React.FC = () => {
@@ -25,8 +26,9 @@ export const ExportForm: React.FC = () => {
     setCurrentJob,
     setArtifacts,
     setArtifactsExpiresAt,
+    setLastExportFormat,
   } = useAppContext();
-  const [format, setFormat] = useState('md');
+  const [format, setFormat] = useState<ExportFormat>('md');
   const [profile, setProfile] = useState('short');
   const [secretScan, setSecretScan] = useState(true);
   const [tokenModel, setTokenModel] = useState('openai');
@@ -117,7 +119,7 @@ export const ExportForm: React.FC = () => {
       owner: repoData.owner,
       repo: repoData.repo,
       ref: repoData.currentRef,
-      format: format as 'zip' | 'md' | 'txt',
+      format,
       profile,
       includeGlobs,
       excludeGlobs,
@@ -130,7 +132,8 @@ export const ExportForm: React.FC = () => {
       .then((resp) => {
         setArtifacts([]);
         setArtifactsExpiresAt(null);
-        setCurrentJob({ id: resp.jobId, state: 'queued', progress: 0 });
+        setLastExportFormat(format);
+        setCurrentJob({ id: resp.jobId, state: 'queued', progress: 0, format });
         setCurrentPage('jobs');
       })
       .catch((err) => {
@@ -156,7 +159,10 @@ export const ExportForm: React.FC = () => {
           {/* Format Selection */}
           <div className="space-y-3">
             <Label className="text-base font-medium">{t.format}</Label>
-            <RadioGroup value={format} onValueChange={setFormat}>
+            <RadioGroup
+              value={format}
+              onValueChange={(value) => setFormat(value as ExportFormat)}
+            >
               <div className="flex items-center space-x-2">
                 <RadioGroupItem value="zip" id="zip" />
                 <Label htmlFor="zip" className="flex items-center gap-2">

--- a/figma/src/components/pages/Jobs.tsx
+++ b/figma/src/components/pages/Jobs.tsx
@@ -1,52 +1,293 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { toast } from 'sonner';
 import { useAppContext } from '../../App';
 import { JobProgress } from '../molecules/JobProgress';
 import { Button } from '../ui/button';
-import { ArrowLeft } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
+import { ArrowLeft, AlertCircle } from 'lucide-react';
+import {
+  artifactsMetaToFiles,
+  cancelJob,
+  getJobStatus,
+  listArtifacts,
+  subscribeToJob,
+} from '../../lib/api';
+import { JobStatusResponse } from '../../lib/types';
+import { Alert, AlertDescription } from '../ui/alert';
 
 export const Jobs: React.FC = () => {
-  const { language, setCurrentPage } = useAppContext();
-  const [jobId] = useState('84213');
-  const [progress, setProgress] = useState(0);
-  const [currentStage, setCurrentStage] = useState(0);
+  const {
+    language,
+    setCurrentPage,
+    currentJob,
+    setCurrentJob,
+    setArtifacts,
+    setArtifactsExpiresAt,
+  } = useAppContext();
+  const [statusError, setStatusError] = useState<string | null>(null);
+  const [isCanceling, setIsCanceling] = useState(false);
+  const [isLoadingStatus, setIsLoadingStatus] = useState(false);
+  const pollTimer = useRef<number | null>(null);
+  const hasFetchedArtifacts = useRef(false);
 
-  const texts = {
-    ru: {
-      title: 'Задача',
-      back: 'Назад',
-    },
-    en: {
-      title: 'Job',
-      back: 'Back',
-    },
-  };
+  const texts = useMemo(
+    () => ({
+      ru: {
+        title: 'Задача',
+        back: 'Назад',
+        emptyTitle: 'Нет активной задачи',
+        emptyDescription:
+          'Создайте экспорт, чтобы отслеживать прогресс выполнения задачи.',
+        toExports: 'К экспортам',
+        toExportSetup: 'К настройкам экспорта',
+        retry: 'Повторить попытку',
+        errors: {
+          status: 'Не удалось получить статус задачи.',
+          events:
+            'Не удалось подключиться к обновлениям. Продолжаем с периодическим опросом…',
+          artifacts: 'Не удалось получить список файлов экспорта.',
+          cancel: 'Не удалось отменить задачу.',
+        },
+        cancelSuccess: 'Запрошено завершение задачи.',
+      },
+      en: {
+        title: 'Job',
+        back: 'Back',
+        emptyTitle: 'No active job',
+        emptyDescription:
+          'Create an export to start tracking the task progress.',
+        toExports: 'Go to exports',
+        toExportSetup: 'Go to export settings',
+        retry: 'Retry',
+        errors: {
+          status: 'Failed to fetch job status.',
+          events:
+            'Live updates are unavailable. Falling back to periodic polling…',
+          artifacts: 'Failed to load export artifacts.',
+          cancel: 'Failed to cancel the job.',
+        },
+        cancelSuccess: 'Cancellation has been requested.',
+      },
+    }),
+    [],
+  );
 
   const t = texts[language];
+  const jobId = currentJob?.id;
 
-  // Simulate job progress
   useEffect(() => {
-    const interval = setInterval(() => {
-      setProgress(prev => {
-        const newProgress = prev + Math.random() * 10;
-        if (newProgress >= 100) {
-          clearInterval(interval);
-          setTimeout(() => setCurrentPage('result'), 1000);
-          return 100;
-        }
-        
-        // Update current stage based on progress
-        if (newProgress > 80) setCurrentStage(5);
-        else if (newProgress > 65) setCurrentStage(4);
-        else if (newProgress > 45) setCurrentStage(3);
-        else if (newProgress > 25) setCurrentStage(2);
-        else if (newProgress > 10) setCurrentStage(1);
-        
-        return newProgress;
-      });
-    }, 500);
+    return () => {
+      if (pollTimer.current) {
+        window.clearInterval(pollTimer.current);
+        pollTimer.current = null;
+      }
+    };
+  }, []);
 
-    return () => clearInterval(interval);
-  }, [setCurrentPage]);
+  useEffect(() => {
+    if (!jobId) {
+      return;
+    }
+
+    let cancelled = false;
+    let source: EventSource | null = null;
+    hasFetchedArtifacts.current = false;
+    setStatusError(null);
+
+    const stopPolling = () => {
+      if (pollTimer.current) {
+        window.clearInterval(pollTimer.current);
+        pollTimer.current = null;
+      }
+    };
+
+    const fetchArtifacts = async (exportId: string) => {
+      try {
+        const response = await listArtifacts(exportId);
+        if (cancelled) {
+          return;
+        }
+        const files = artifactsMetaToFiles(response.files);
+        setArtifacts(files);
+        setArtifactsExpiresAt(response.expiresAt);
+        hasFetchedArtifacts.current = true;
+        setCurrentPage('result');
+      } catch (err) {
+        console.error('Failed to load artifacts', err);
+        if (!cancelled) {
+          setStatusError(t.errors.artifacts);
+        }
+        hasFetchedArtifacts.current = true;
+      }
+    };
+
+    const applyStatus = (payload: JobStatusResponse) => {
+      if (cancelled) {
+        return;
+      }
+
+      setCurrentJob((prev) => {
+        if (!prev || prev.id !== jobId) {
+          return prev;
+        }
+        return {
+          ...prev,
+          state: payload.state,
+          progress: payload.progress,
+          error: payload.error ?? prev.error ?? null,
+          failureReason: payload.failureReason ?? prev.failureReason ?? null,
+          cancelRequested: payload.cancelRequested ?? prev.cancelRequested,
+          exportId: payload.exportId ?? prev.exportId,
+          artifacts: payload.artifacts ?? prev.artifacts,
+        };
+      });
+
+      if (payload.artifacts?.length) {
+        const files = artifactsMetaToFiles(payload.artifacts);
+        if (files.length) {
+          setArtifacts(files);
+        }
+      }
+
+      const state = payload.state;
+      const exportId = payload.exportId ?? currentJob?.exportId;
+
+      if (state === 'done' && exportId && !hasFetchedArtifacts.current) {
+        fetchArtifacts(exportId);
+      }
+
+      if (state === 'error' || state === 'cancelled') {
+        stopPolling();
+      }
+
+      if (state === 'done' || state === 'error' || state === 'cancelled') {
+        if (source) {
+          source.close();
+          source = null;
+        }
+      }
+    };
+
+    const startPolling = () => {
+      if (pollTimer.current) {
+        return;
+      }
+      pollTimer.current = window.setInterval(async () => {
+        try {
+          const status = await getJobStatus(jobId);
+          applyStatus(status);
+        } catch (err) {
+          console.error('Failed to poll job status', err);
+          if (!cancelled) {
+            setStatusError(t.errors.status);
+          }
+        }
+      }, 5000);
+    };
+
+    const init = async () => {
+      setIsLoadingStatus(true);
+      try {
+        const initial = await getJobStatus(jobId);
+        applyStatus(initial);
+      } catch (err) {
+        console.error('Failed to load initial job status', err);
+        if (!cancelled) {
+          setStatusError(t.errors.status);
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoadingStatus(false);
+        }
+      }
+
+      try {
+        source = subscribeToJob(
+          jobId,
+          (payload) => {
+            setStatusError(null);
+            applyStatus(payload);
+          },
+          () => {
+            if (!cancelled) {
+              setStatusError(t.errors.events);
+              startPolling();
+            }
+          },
+        );
+      } catch (err) {
+        console.error('Failed to subscribe to job events', err);
+        if (!cancelled) {
+          setStatusError(t.errors.events);
+          startPolling();
+        }
+      }
+    };
+
+    init();
+
+    return () => {
+      cancelled = true;
+      if (source) {
+        source.close();
+      }
+      stopPolling();
+    };
+  }, [currentJob?.exportId, jobId, language, setArtifacts, setArtifactsExpiresAt, setCurrentJob, setCurrentPage, t.errors.artifacts, t.errors.events, t.errors.status]);
+
+  const handleCancel = async () => {
+    if (!currentJob) {
+      return;
+    }
+    setIsCanceling(true);
+    setCurrentJob((prev) =>
+      prev && prev.id === currentJob.id
+        ? { ...prev, cancelRequested: true }
+        : prev,
+    );
+    try {
+      await cancelJob(currentJob.id);
+      toast.success(t.cancelSuccess);
+    } catch (err) {
+      console.error('Failed to cancel job', err);
+      setCurrentJob((prev) =>
+        prev && prev.id === currentJob.id
+          ? { ...prev, cancelRequested: false }
+          : prev,
+      );
+      toast.error(t.errors.cancel);
+    } finally {
+      setIsCanceling(false);
+    }
+  };
+
+  if (!currentJob) {
+    return (
+      <div className="min-h-screen bg-background">
+        <div className="container mx-auto px-4 py-12 max-w-2xl">
+          <Card>
+            <CardHeader>
+              <CardTitle>{t.emptyTitle}</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <p className="text-muted-foreground">{t.emptyDescription}</p>
+              <div className="flex flex-wrap gap-3">
+                <Button onClick={() => setCurrentPage('exports')}>
+                  {t.toExports}
+                </Button>
+                <Button variant="outline" onClick={() => setCurrentPage('export')}>
+                  {t.toExportSetup}
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    );
+  }
+
+  const combinedError =
+    statusError ?? currentJob.error ?? currentJob.failureReason ?? null;
 
   return (
     <div className="min-h-screen bg-background">
@@ -54,11 +295,11 @@ export const Jobs: React.FC = () => {
         <div className="flex items-center justify-between mb-8">
           <div>
             <h1 className="text-3xl font-bold">
-              {t.title} #{jobId}
+              {t.title} #{currentJob.id}
             </h1>
           </div>
-          <Button 
-            variant="ghost" 
+          <Button
+            variant="ghost"
             onClick={() => setCurrentPage('export')}
             className="gap-2"
           >
@@ -67,10 +308,25 @@ export const Jobs: React.FC = () => {
           </Button>
         </div>
 
-        <JobProgress 
-          progress={progress}
-          currentStage={currentStage}
-          jobId={jobId}
+        {isLoadingStatus && (
+          <Alert className="mb-4">
+            <AlertCircle className="h-4 w-4" />
+            <AlertDescription>
+              {language === 'ru'
+                ? 'Обновляем состояние задачи…'
+                : 'Fetching the latest job state…'}
+            </AlertDescription>
+          </Alert>
+        )}
+
+        <JobProgress
+          jobId={currentJob.id}
+          progress={Math.max(0, currentJob.progress ?? 0)}
+          state={currentJob.state}
+          error={combinedError}
+          onCancel={handleCancel}
+          cancelDisabled={isCanceling}
+          cancelRequested={currentJob.cancelRequested}
         />
       </div>
     </div>

--- a/figma/src/components/pages/Result.tsx
+++ b/figma/src/components/pages/Result.tsx
@@ -1,88 +1,157 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useAppContext } from '../../App';
 import { ArtifactsList } from '../molecules/ArtifactsList';
+import { QuickTextExport } from '../molecules/QuickTextExport';
 import { Button } from '../ui/button';
 import { Alert, AlertDescription } from '../ui/alert';
+import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
 import { CheckCircle2, Plus } from 'lucide-react';
-import { ArtifactFile } from '../../lib/types';
+import { ArtifactFile, ExportFormat } from '../../lib/types';
+
+const sortArtifactsByFormat = (
+  artifacts: ArtifactFile[],
+  preferredFormat: ExportFormat | null,
+): ArtifactFile[] => {
+  if (!preferredFormat) {
+    return [...artifacts];
+  }
+  return [...artifacts].sort((a, b) => {
+    const aPreferred = a.kind?.toLowerCase() === preferredFormat;
+    const bPreferred = b.kind?.toLowerCase() === preferredFormat;
+    if (aPreferred === bPreferred) {
+      return (a.name || '').localeCompare(b.name || '');
+    }
+    return aPreferred ? -1 : 1;
+  });
+};
 
 export const Result: React.FC = () => {
-  const { language, setCurrentPage } = useAppContext();
+  const {
+    language,
+    setCurrentPage,
+    artifacts,
+    artifactsExpiresAt,
+    lastExportFormat,
+  } = useAppContext();
 
-  const texts = {
-    ru: {
-      title: 'Готово!',
-      description: 'Ваш экспорт успешно создан',
-      ttlWarning: 'Ссылки истекут через 72 часа',
-      createAnother: 'Создать ещё',
-      backToStart: 'К началу',
-    },
-    en: {
-      title: 'Done!',
-      description: 'Your export has been created successfully',
-      ttlWarning: 'Links will expire in 72 hours',
-      createAnother: 'Create another',
-      backToStart: 'Back to start',
-    },
-  };
+  const texts = useMemo(
+    () => ({
+      ru: {
+        title: 'Готово!',
+        description: 'Ваш экспорт успешно создан',
+        emptyTitle: 'Артефакты не найдены',
+        emptyDescription:
+          'Попробуйте обновить страницу или создать экспорт повторно.',
+        ttl: (date: string) => `Ссылки истекут ${date}`,
+        ttlUnknown: 'Срок действия ссылок ограничен (до 72 часов).',
+        createAnother: 'Создать ещё',
+        backToStart: 'К началу',
+        goToExports: 'К экспортам',
+      },
+      en: {
+        title: 'Done!',
+        description: 'Your export has been created successfully',
+        emptyTitle: 'No artifacts found',
+        emptyDescription: 'Try refreshing the page or creating the export again.',
+        ttl: (date: string) => `Links will expire on ${date}`,
+        ttlUnknown: 'Links are available for a limited time (up to 72 hours).',
+        createAnother: 'Create another',
+        backToStart: 'Back to start',
+        goToExports: 'Go to exports',
+      },
+    }),
+    [],
+  );
 
   const t = texts[language];
 
-  const mockArtifacts: ArtifactFile[] = [
-    {
-      id: '1',
-      name: 'PromptPack-Short.md',
-      kind: 'md',
-      size: 131072,
-      downloadUrl: '#',
-    },
-    {
-      id: '2',
-      name: 'Export.zip',
-      kind: 'zip',
-      size: 14876672,
-      downloadUrl: '#',
-    },
-    {
-      id: '3',
-      name: 'Concat.txt',
-      kind: 'txt',
-      size: 1363149,
-      downloadUrl: '#',
-    },
-  ];
+  const sortedArtifacts = useMemo(
+    () => sortArtifactsByFormat(artifacts, lastExportFormat ?? null),
+    [artifacts, lastExportFormat],
+  );
+
+  const primaryArtifact = sortedArtifacts[0] ?? null;
+  const textArtifact = useMemo(
+    () => sortedArtifacts.find((artifact) => artifact.kind === 'txt') ?? null,
+    [sortedArtifacts],
+  );
+
+  const expiresLabel = useMemo(() => {
+    if (!artifactsExpiresAt) {
+      return null;
+    }
+    try {
+      const date = new Date(artifactsExpiresAt);
+      if (Number.isNaN(date.getTime())) {
+        return null;
+      }
+      const locale = language === 'ru' ? 'ru-RU' : 'en-US';
+      return new Intl.DateTimeFormat(locale, {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+      }).format(date);
+    } catch {
+      return null;
+    }
+  }, [artifactsExpiresAt, language]);
+
+  const handleCreateAnother = () => setCurrentPage('select');
+  const handleBackToLanding = () => setCurrentPage('landing');
+  const handleGoToExports = () => setCurrentPage('exports');
+
+  if (!sortedArtifacts.length) {
+    return (
+      <div className="min-h-screen bg-background">
+        <div className="container mx-auto px-4 py-12 max-w-3xl">
+          <Card className="border-dashed">
+            <CardHeader className="text-center space-y-2">
+              <CardTitle className="text-2xl font-semibold">
+                {t.emptyTitle}
+              </CardTitle>
+              <p className="text-muted-foreground">{t.emptyDescription}</p>
+            </CardHeader>
+            <CardContent className="flex flex-wrap items-center justify-center gap-3">
+              <Button onClick={handleGoToExports}>{t.goToExports}</Button>
+              <Button variant="outline" onClick={handleCreateAnother}>
+                {t.createAnother}
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-background">
-      <div className="container mx-auto px-4 py-8 max-w-4xl">
-        <div className="text-center mb-8">
-          <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4">
+      <div className="container mx-auto px-4 py-8 max-w-4xl space-y-8">
+        <div className="text-center space-y-4">
+          <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto">
             <CheckCircle2 className="w-8 h-8 text-green-600" />
           </div>
-          <h1 className="text-3xl font-bold mb-2">{t.title}</h1>
+          <h1 className="text-3xl font-bold">{t.title}</h1>
           <p className="text-muted-foreground">{t.description}</p>
         </div>
 
         <div className="space-y-6">
           <Alert>
             <AlertDescription>
-              {t.ttlWarning}
+              {expiresLabel ? t.ttl(expiresLabel) : t.ttlUnknown}
             </AlertDescription>
           </Alert>
 
-          <ArtifactsList artifacts={mockArtifacts} />
+          <ArtifactsList
+            artifacts={sortedArtifacts}
+            primaryArtifactId={primaryArtifact?.id ?? null}
+          />
 
-          <div className="flex justify-center gap-4 pt-6">
-            <Button 
-              variant="outline"
-              onClick={() => setCurrentPage('landing')}
-            >
+          {textArtifact && <QuickTextExport artifact={textArtifact} />}
+
+          <div className="flex flex-wrap justify-center gap-4 pt-4">
+            <Button variant="outline" onClick={handleBackToLanding}>
               {t.backToStart}
             </Button>
-            <Button 
-              onClick={() => setCurrentPage('select')}
-              className="gap-2"
-            >
+            <Button onClick={handleCreateAnother} className="gap-2">
               <Plus className="w-4 h-4" />
               {t.createAnother}
             </Button>

--- a/figma/src/lib/api.ts
+++ b/figma/src/lib/api.ts
@@ -1,6 +1,8 @@
 import {
   ApiErrorPayload,
   ArtifactsResponse,
+  ArtifactFile,
+  ArtifactMeta,
   ExportRequest,
   ExportResponse,
   JobStatusResponse,
@@ -104,6 +106,28 @@ export const listArtifacts = (exportId: string): Promise<ArtifactsResponse> =>
   request<ArtifactsResponse>(`/api/artifacts/${encodeURIComponent(exportId)}`);
 
 export const getDownloadUrl = (artifactId: string): string => buildUrl(`/api/download/${encodeURIComponent(artifactId)}`);
+
+export const artifactMetaToFile = (meta: ArtifactMeta): ArtifactFile | null => {
+  if (!meta.id) {
+    return null;
+  }
+  return {
+    id: meta.id,
+    kind: meta.kind,
+    name: meta.name,
+    size: meta.size,
+    downloadUrl: getDownloadUrl(meta.id),
+  };
+};
+
+export const artifactsMetaToFiles = (artifacts: ArtifactMeta[] | undefined | null): ArtifactFile[] => {
+  if (!artifacts?.length) {
+    return [];
+  }
+  return artifacts
+    .map(artifactMetaToFile)
+    .filter((file): file is ArtifactFile => Boolean(file));
+};
 
 export const subscribeToJob = (
   jobId: string,

--- a/figma/src/lib/types.ts
+++ b/figma/src/lib/types.ts
@@ -74,11 +74,13 @@ export interface PreviewResponse {
   truncated: boolean;
 }
 
+export type ExportFormat = 'zip' | 'md' | 'txt';
+
 export interface ExportRequest {
   owner: string;
   repo: string;
   ref: string;
-  format: 'zip' | 'md' | 'txt';
+  format: ExportFormat;
   profile: string;
   includeGlobs: string[];
   excludeGlobs: string[];
@@ -95,12 +97,23 @@ export interface ExportResponse {
 
 export type JobStatus = 'queued' | 'running' | 'done' | 'error' | 'cancelled';
 
+export interface ArtifactMeta {
+  id?: string;
+  kind?: string;
+  name: string;
+  size?: number;
+  path?: string;
+  contentType?: string;
+  checksum?: string;
+  meta?: Record<string, unknown>;
+}
+
 export interface JobStatusResponse {
   state: JobStatus;
   progress: number;
   error?: string | null;
   exportId?: string;
-  artifacts?: Array<{ id: string; kind: string; size: number }>;
+  artifacts?: ArtifactMeta[];
   failureReason?: string | null;
   cancelRequested?: boolean;
 }
@@ -113,18 +126,20 @@ export interface JobState {
   exportId?: string;
   failureReason?: string | null;
   cancelRequested?: boolean;
+  artifacts?: ArtifactMeta[];
+  format?: ExportFormat;
 }
 
 export interface ArtifactFile {
   id: string;
-  kind: string;
+  kind?: string;
   name: string;
-  size: number;
+  size?: number;
   downloadUrl: string;
 }
 
 export interface ArtifactsResponse {
-  files: Array<{ id: string; kind: string; name: string; size: number }>;
+  files: ArtifactMeta[];
   expiresAt: string;
 }
 


### PR DESCRIPTION
## Summary
- persist the selected export format in the global state when creating a job
- stream real job status updates, load artifacts on completion, and handle cancellations gracefully
- refresh the result and artifact views with highlighted formats, text previews, and reliable downloads

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68deae996abc832c8707431c3a577070